### PR TITLE
Stabilize recDL session restart and cleanup

### DIFF
--- a/recDL.xcodeproj/project.pbxproj
+++ b/recDL.xcodeproj/project.pbxproj
@@ -391,7 +391,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 2026.05.06;
+				CURRENT_PROJECT_VERSION = 2026.05.10;
 				DEAD_CODE_STRIPPING = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -404,7 +404,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.10.1;
+				MARKETING_VERSION = 0.10.2b1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mycometg3.recDL;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 6.0;
@@ -420,7 +420,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 2026.05.06;
+				CURRENT_PROJECT_VERSION = 2026.05.10;
 				DEAD_CODE_STRIPPING = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -433,7 +433,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.10.1;
+				MARKETING_VERSION = 0.10.2b1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mycometg3.recDL;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 6.0;

--- a/recDL/AppDelegate+Preferences.swift
+++ b/recDL/AppDelegate+Preferences.swift
@@ -423,8 +423,10 @@ extension AppDelegate {
     }
     
     private func fieldDominanceForTag(_ tag:Int) -> DLABFieldDominance {
-        let fdList:[DLABFieldDominance] =
-        [.progressiveFrame, .lowerFieldFirst, .upperFieldFirst]
+        let fdList:[DLABFieldDominance] = [.progressiveFrame, .lowerFieldFirst, .upperFieldFirst]
+        guard fdList.indices.contains(tag) else {
+            return .progressiveFrame
+        }
         let fd = fdList[tag]
         return fd
     }

--- a/recDL/AppDelegate+Session.swift
+++ b/recDL/AppDelegate+Session.swift
@@ -180,7 +180,7 @@ extension AppDelegate {
         let result = await self.captureSession.startCaptureSession()
         if result {
             printVerbose("NOTICE:\(self.className): \(#function) - Starting capture session completed.")
-            updateCachedState()
+            await refreshCachedState()
             
             Task(priority: .utility) { [captureSession] in
                 _ = await captureSession.prewarmRecordingPath()
@@ -204,7 +204,7 @@ extension AppDelegate {
             
             await self.captureSession.destroyManager()
             self.manager = nil
-            updateCachedState()
+            await refreshCachedState()
         } else {
             printVerbose("ERROR:\(self.className): \(#function) - CaptureManager is nil.")
         }
@@ -213,6 +213,11 @@ extension AppDelegate {
     public func restartSession(_ notification: Notification) {
         // print("\(#file) \(#line) \(#function)")
         
+        guard restartSessionTask == nil else {
+            printVerbose("NOTICE:\(self.className): \(#function) - Restart already in progress")
+            return
+        }
+        
         // Check user choosen input port (audio/video)
         // modify if required
         if manager == nil {
@@ -220,10 +225,13 @@ extension AppDelegate {
             return
         }
         
-        Task { @MainActor [weak self] in
+        restartSessionTask = Task { @MainActor [weak self] in
             guard let self = self else {
                 AppDelegate.printNilSelfWarning(#function)
                 return
+            }
+            defer {
+                self.restartSessionTask = nil
             }
             
             // Stop Session
@@ -250,7 +258,7 @@ extension AppDelegate {
             self.setVolume(-1)              // Update Popup Menu Selection
             
             // Update cached recording state after restart
-            self.updateCachedState()
+            await self.refreshCachedState()
         }
     }
     

--- a/recDL/AppDelegate+Session.swift
+++ b/recDL/AppDelegate+Session.swift
@@ -577,8 +577,8 @@ extension AppDelegate {
         // Update recording button as released state
         recordingButton.state = NSControl.StateValue.off
         
-        // Reset dock icon and badge on the next main runloop turn.
-        RunLoop.main.perform(inModes: [.common]) { [weak self] in
+        // Reset dock icon and badge on the next main queue turn.
+        DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
             NSApp.dockTile.badgeLabel = nil
             NSApp.applicationIconImage = self.iconIdle

--- a/recDL/AppDelegate+Session.swift
+++ b/recDL/AppDelegate+Session.swift
@@ -233,20 +233,18 @@ extension AppDelegate {
             defer {
                 self.restartSessionTask = nil
             }
-            
+            // Stop Session
+            self.stopUpdateStatus()
+            self.defaults.set(false, forKey: Keys.showAlternate)
+
+            self.removePreviewLayer()
+            self.manager?.videoPreview = nil
+            await self.stopSession()
+
             do {
-                // Stop Session
-                self.stopUpdateStatus()
-                self.defaults.set(false, forKey: Keys.showAlternate)
-                
-                self.removePreviewLayer()
-                self.manager?.videoPreview = nil
-                await self.stopSession()
-                
                 // Cancel before restarting to avoid leaving the session in a stopped state
                 try Task.checkCancellation()
                 
-                //
                 try await Task.sleep(nanoseconds: 100_000_000) // sleep for 0.1 seconds
                 
                 // Start Session
@@ -263,8 +261,10 @@ extension AppDelegate {
                 
                 // Update cached recording state after restart
                 await self.refreshCachedState()
-            } catch {
+            } catch is CancellationError {
                 // Task was cancelled; defer block clears restartSessionTask
+            } catch {
+                self.printVerbose("ERROR:\(self.className): \(#function) - Restart failed: \(error.localizedDescription)")
             }
         }
     }

--- a/recDL/AppDelegate+Session.swift
+++ b/recDL/AppDelegate+Session.swift
@@ -587,13 +587,8 @@ extension AppDelegate {
         recordingButton.state = NSControl.StateValue.off
         
         // Reset dock icon and badge
-        Task(priority: .background) {
-            // Reset AppIcon badge to inactive state
-            NSApp.dockTile.badgeLabel = nil
-            
-            // Reset AppIcon animation to inactive state
-            NSApp.applicationIconImage = iconIdle
-        }
+        NSApp.dockTile.badgeLabel = nil
+        NSApp.applicationIconImage = iconIdle
         
         // Post notification without userInfo
         let notification = Notification(name: .recordingStoppedNotificationKey,

--- a/recDL/AppDelegate+Session.swift
+++ b/recDL/AppDelegate+Session.swift
@@ -251,8 +251,6 @@ extension AppDelegate {
                 
                 // Start Session
                 await self.startSession()
-                self.manager?.videoPreview = self.parentView
-                self.addPreviewLayer()
                 
                 self.defaults.set(false, forKey: Keys.showAlternate)
                 self.startUpdateStatus()
@@ -478,12 +476,7 @@ extension AppDelegate {
             return
         }
         
-        // Optimistically set cached state before the actor call so the 0.5s
-        // updateTimer sees the correct state immediately. The defer block
-        // reconciles the cache against the actor result on both success and
-        // failure paths.
         recordingStartInProgress = true
-        cachedRecordingState = true
         defer {
             recordingStartInProgress = false
             updateCachedStateAsync()
@@ -649,7 +642,7 @@ extension AppDelegate {
         }
     }
     
-    internal func invalidateStopTimer() {
+    private func invalidateStopTimer() {
         // print("\(#file) \(#line) \(#function)")
         
         // Release StopTimer

--- a/recDL/AppDelegate+Session.swift
+++ b/recDL/AppDelegate+Session.swift
@@ -586,9 +586,12 @@ extension AppDelegate {
         // Update recording button as released state
         recordingButton.state = NSControl.StateValue.off
         
-        // Reset dock icon and badge
-        NSApp.dockTile.badgeLabel = nil
-        NSApp.applicationIconImage = iconIdle
+        // Reset dock icon and badge on the next main runloop turn.
+        RunLoop.main.perform(inModes: [.common]) { [weak self] in
+            guard let self = self else { return }
+            NSApp.dockTile.badgeLabel = nil
+            NSApp.applicationIconImage = self.iconIdle
+        }
         
         // Post notification without userInfo
         let notification = Notification(name: .recordingStoppedNotificationKey,

--- a/recDL/AppDelegate+Session.swift
+++ b/recDL/AppDelegate+Session.swift
@@ -468,9 +468,16 @@ extension AppDelegate {
             printVerbose("ERROR:\(self.className): \(#function) - Failed to start recording")
             return
         }
+        
+        // Optimistically set cached state before the actor call so the 0.5s
+        // updateTimer sees the correct state immediately. The defer block
+        // reconciles the cache against the actor result on both success and
+        // failure paths.
         recordingStartInProgress = true
+        cachedRecordingState = true
         defer {
             recordingStartInProgress = false
+            updateCachedStateAsync()
         }
         
         let startedAt = CFAbsoluteTimeGetCurrent()
@@ -479,9 +486,6 @@ extension AppDelegate {
         applyRecordingParameters()
         
         let recordingStarted = await self.captureSession.startRecording(to: movieURL)
-        
-        // Refresh cache asynchronously to keep the hot path non-blocking.
-        updateCachedStateAsync()
         
         if recordingStarted {
             // Schedule StopTimer if required
@@ -508,12 +512,11 @@ extension AppDelegate {
             
             let elapsedMs = Int((CFAbsoluteTimeGetCurrent() - startedAt) * 1000.0)
             printVerbose("TRACE:\(self.className): \(#function) - success \(elapsedMs)ms ")
-            return
+        } else {
+            let elapsedMs = Int((CFAbsoluteTimeGetCurrent() - startedAt) * 1000.0)
+            printVerbose("TRACE:\(self.className): \(#function) - failed \(elapsedMs)ms ")
+            printVerbose("ERROR:\(self.className): \(#function) - Failed to start recording")
         }
-        
-        let elapsedMs = Int((CFAbsoluteTimeGetCurrent() - startedAt) * 1000.0)
-        printVerbose("TRACE:\(self.className): \(#function) - failed \(elapsedMs)ms ")
-        printVerbose("ERROR:\(self.className): \(#function) - Failed to start recording")
     }
     
     /// Synchronous stop path for AppleScript/script callers.
@@ -566,7 +569,9 @@ extension AppDelegate {
     }
     
     private func finishRecordingStop() {
-        // Release StopTimer
+        // Eagerly clear cached state so the 0.5s timer stops animation immediately.
+        cachedRecordingState = false
+        
         invalidateStopTimer()
         
         // Update recording button as released state

--- a/recDL/AppDelegate+Session.swift
+++ b/recDL/AppDelegate+Session.swift
@@ -259,8 +259,6 @@ extension AppDelegate {
                 self.setScale(-1)               // Update Popup Menu Selection
                 self.setVolume(-1)              // Update Popup Menu Selection
                 
-                // Update cached recording state after restart
-                await self.refreshCachedState()
             } catch is CancellationError {
                 // Task was cancelled; defer block clears restartSessionTask
             } catch {

--- a/recDL/AppDelegate+Session.swift
+++ b/recDL/AppDelegate+Session.swift
@@ -243,8 +243,8 @@ extension AppDelegate {
             self.manager?.videoPreview = nil
             await self.stopSession()
 
+            // Honor cancellation before starting a fresh session.
             do {
-                // Cancel before restarting to avoid leaving the session in a stopped state
                 try Task.checkCancellation()
                 
                 try await Task.sleep(nanoseconds: 100_000_000) // sleep for 0.1 seconds

--- a/recDL/AppDelegate+Session.swift
+++ b/recDL/AppDelegate+Session.swift
@@ -649,7 +649,7 @@ extension AppDelegate {
         }
     }
     
-    private func invalidateStopTimer() {
+    internal func invalidateStopTimer() {
         // print("\(#file) \(#line) \(#function)")
         
         // Release StopTimer

--- a/recDL/AppDelegate+Session.swift
+++ b/recDL/AppDelegate+Session.swift
@@ -108,7 +108,7 @@ extension AppDelegate {
     // MARK: - Capture Session support
     /* ======================================================================================== */
     
-    private func applySessionParameters() {
+    private func applySessionParametersAsync() async {
         // Read parameters for session
         let displayModeRaw : UInt32 = UInt32(defaults.integer(forKey: Keys.displayMode))
         guard let displayMode = DLABDisplayMode(rawValue: displayModeRaw) else { return }
@@ -145,45 +145,39 @@ extension AppDelegate {
         }
         
         // Apply parameters through actor
-        performAsync {
-            await self.captureSession.applySessionParameters(
-                displayMode: displayMode,
-                videoConnection: videoConnection,
-                audioConnection: audioConnection,
-                pixelFormat: pixelFormat,
-                videoStyle: videoStyle,
-                audioDepth: audioDepth,
-                audioChannels: audioChannel,
-                hdmiAudioChannels: hdmiAudioChannels,
-                reverseCh3Ch4: reverseCh3Ch4,
-                timecodeSource: timecodeSource
-            )
-        }
+        await self.captureSession.applySessionParameters(
+            displayMode: displayMode,
+            videoConnection: videoConnection,
+            audioConnection: audioConnection,
+            pixelFormat: pixelFormat,
+            videoStyle: videoStyle,
+            audioDepth: audioDepth,
+            audioChannels: audioChannel,
+            hdmiAudioChannels: hdmiAudioChannels,
+            reverseCh3Ch4: reverseCh3Ch4,
+            timecodeSource: timecodeSource
+        )
     }
     
-    public func startSession() {
+    public func startSession() async {
         // print("\(#file) \(#line) \(#function)")
         
         // Create manager through actor and set as local reference
         let verbose = self.verbose
-        manager = performAsync {
-            await self.captureSession.setVerbose(verbose)
-            return await self.captureSession.createManager()
-        }
+        await self.captureSession.setVerbose(verbose)
+        manager = await self.captureSession.createManager()
         
         guard manager != nil else {
             printVerbose("ERROR:\(self.className): \(#function) - Failed to create CaptureManager.")
             return
         }
         
-        applySessionParameters()
+        await applySessionParametersAsync()
         
         addPreviewLayer()
         
         printVerbose("NOTICE:\(self.className): \(#function) - Starting capture session...")
-        let result = performAsync {
-            await self.captureSession.startCaptureSession()
-        }
+        let result = await self.captureSession.startCaptureSession()
         if result {
             printVerbose("NOTICE:\(self.className): \(#function) - Starting capture session completed.")
             updateCachedState()
@@ -196,23 +190,19 @@ extension AppDelegate {
         }
     }
     
-    public func stopSession() {
+    public func stopSession() async {
         // print("\(#file) \(#line) \(#function)")
         
         if manager != nil {
             printVerbose("NOTICE:\(self.className): \(#function) - Stopping capture session...")
-            let result = performAsync {
-                await self.captureSession.stopCaptureSession()
-            }
+            let result = await self.captureSession.stopCaptureSession()
             if result {
                 printVerbose("NOTICE:\(self.className): \(#function) - Stopping capture session completed.")
             } else {
                 printVerbose("ERROR:\(self.className): \(#function) - Stopping capture session failed.")
             }
             
-            performAsync {
-                await self.captureSession.destroyManager()
-            }
+            await self.captureSession.destroyManager()
             self.manager = nil
             updateCachedState()
         } else {
@@ -242,13 +232,13 @@ extension AppDelegate {
             
             self.removePreviewLayer()
             self.manager?.videoPreview = nil
-            self.stopSession()
+            await self.stopSession()
             
             //
             try? await Task.sleep(nanoseconds: 100_000_000) // sleep for 0.1 seconds
             
             // Start Session
-            self.startSession()
+            await self.startSession()
             self.manager?.videoPreview = self.parentView
             self.addPreviewLayer()
             

--- a/recDL/AppDelegate+Session.swift
+++ b/recDL/AppDelegate+Session.swift
@@ -516,6 +516,9 @@ extension AppDelegate {
         printVerbose("ERROR:\(self.className): \(#function) - Failed to start recording")
     }
     
+    /// Synchronous stop path for AppleScript/script callers.
+    /// Timer-driven stops use `stopRecordingFromTimer()` so the main thread does not wait on
+    /// `performAsync { semaphore.wait() }`.
     public func stopRecording() {
         // print("\(#file) \(#line) \(#function)")
         
@@ -534,50 +537,72 @@ extension AppDelegate {
             updateCachedState()
             
             if recordingStopped {
-                
-                // Release StopTimer
-                invalidateStopTimer()
-                
-                // Update recording button as released state
-                recordingButton.state = NSControl.StateValue.off
-                
-                // Reset dock icon and badge
-                Task(priority: .background) {
-                    // Reset AppIcon badge to inactive state
-                    NSApp.dockTile.badgeLabel = nil
-                    
-                    // Reset AppIcon animation to inactive state
-                    NSApp.applicationIconImage = iconIdle
-                }
-                
-                // Post notification without userInfo
-                let notification = Notification(name: .recordingStoppedNotificationKey,
-                                                object: self,
-                                                userInfo: nil)
-                notificationCenter.post(notification)
-                
-                // Evaluate AutoQuit after finished
-                if evalAutoQuitFlag && defaults.bool(forKey: Keys.autoQuit) {
-                    printVerbose("NOTICE:\(self.className): \(#function) - AutoQuit triggered")
-                    
-                    let selector = #selector(NSApplication.terminate(_:))
-                    NSApp.perform(selector,
-                                  with: nil,
-                                  afterDelay: 0.1,
-                                  inModes: [.common])
-                    /*
-                     * Calling NSApp.terminate() directly causes a deadlock with
-                     * NSApplication.TerminateReply.terminateLater.
-                     * Instead, trigger termination using performSelector method.
-                     * NSApp.terminate(self)
-                     */
-                }
-                
+                finishRecordingStop()
                 return
             }
         }
         
         printVerbose("ERROR:\(self.className): \(#function) - Failed to stop recording")
+    }
+    
+    @objc
+    private func stopRecordingFromTimer() {
+        Task { @MainActor [weak self] in
+            guard let self = self else {
+                AppDelegate.printNilSelfWarning(#function)
+                return
+            }
+            
+            let recordingStopped = await self.captureSession.stopRecording()
+            await self.refreshCachedState()
+            
+            if recordingStopped {
+                self.finishRecordingStop()
+                return
+            }
+            
+            self.printVerbose("ERROR:\(self.className): \(#function) - Failed to stop recording")
+        }
+    }
+    
+    private func finishRecordingStop() {
+        // Release StopTimer
+        invalidateStopTimer()
+        
+        // Update recording button as released state
+        recordingButton.state = NSControl.StateValue.off
+        
+        // Reset dock icon and badge
+        Task(priority: .background) {
+            // Reset AppIcon badge to inactive state
+            NSApp.dockTile.badgeLabel = nil
+            
+            // Reset AppIcon animation to inactive state
+            NSApp.applicationIconImage = iconIdle
+        }
+        
+        // Post notification without userInfo
+        let notification = Notification(name: .recordingStoppedNotificationKey,
+                                        object: self,
+                                        userInfo: nil)
+        notificationCenter.post(notification)
+        
+        // Evaluate AutoQuit after finished
+        if evalAutoQuitFlag && defaults.bool(forKey: Keys.autoQuit) {
+            printVerbose("NOTICE:\(self.className): \(#function) - AutoQuit triggered")
+            
+            let selector = #selector(NSApplication.terminate(_:))
+            NSApp.perform(selector,
+                          with: nil,
+                          afterDelay: 0.1,
+                          inModes: [.common])
+            /*
+             * Calling NSApp.terminate() directly causes a deadlock with
+             * NSApplication.TerminateReply.terminateLater.
+             * Instead, trigger termination using performSelector method.
+             * NSApp.terminate(self)
+             */
+        }
     }
     
     private func scheduleStopTimer(_ sec: Int) {
@@ -598,7 +623,7 @@ extension AppDelegate {
             
             stopTimer = Timer.scheduledTimer(timeInterval: limit,
                                              target: self,
-                                             selector: #selector(stopRecording),
+                                             selector: #selector(stopRecordingFromTimer),
                                              userInfo: nil,
                                              repeats: false)
             

--- a/recDL/AppDelegate+Session.swift
+++ b/recDL/AppDelegate+Session.swift
@@ -195,6 +195,8 @@ extension AppDelegate {
         
         if manager != nil {
             printVerbose("NOTICE:\(self.className): \(#function) - Stopping capture session...")
+            invalidateStopTimer()
+            evalAutoQuitFlag = false
             let result = await self.captureSession.stopCaptureSession()
             if result {
                 printVerbose("NOTICE:\(self.className): \(#function) - Stopping capture session completed.")

--- a/recDL/AppDelegate+Session.swift
+++ b/recDL/AppDelegate+Session.swift
@@ -234,31 +234,38 @@ extension AppDelegate {
                 self.restartSessionTask = nil
             }
             
-            // Stop Session
-            self.stopUpdateStatus()
-            self.defaults.set(false, forKey: Keys.showAlternate)
-            
-            self.removePreviewLayer()
-            self.manager?.videoPreview = nil
-            await self.stopSession()
-            
-            //
-            try? await Task.sleep(nanoseconds: 100_000_000) // sleep for 0.1 seconds
-            
-            // Start Session
-            await self.startSession()
-            self.manager?.videoPreview = self.parentView
-            self.addPreviewLayer()
-            
-            self.defaults.set(false, forKey: Keys.showAlternate)
-            self.startUpdateStatus()
-            
-            // Update Toolbar button title
-            self.setScale(-1)               // Update Popup Menu Selection
-            self.setVolume(-1)              // Update Popup Menu Selection
-            
-            // Update cached recording state after restart
-            await self.refreshCachedState()
+            do {
+                // Stop Session
+                self.stopUpdateStatus()
+                self.defaults.set(false, forKey: Keys.showAlternate)
+                
+                self.removePreviewLayer()
+                self.manager?.videoPreview = nil
+                await self.stopSession()
+                
+                // Cancel before restarting to avoid leaving the session in a stopped state
+                try Task.checkCancellation()
+                
+                //
+                try await Task.sleep(nanoseconds: 100_000_000) // sleep for 0.1 seconds
+                
+                // Start Session
+                await self.startSession()
+                self.manager?.videoPreview = self.parentView
+                self.addPreviewLayer()
+                
+                self.defaults.set(false, forKey: Keys.showAlternate)
+                self.startUpdateStatus()
+                
+                // Update Toolbar button title
+                self.setScale(-1)               // Update Popup Menu Selection
+                self.setVolume(-1)              // Update Popup Menu Selection
+                
+                // Update cached recording state after restart
+                await self.refreshCachedState()
+            } catch {
+                // Task was cancelled; defer block clears restartSessionTask
+            }
         }
     }
     

--- a/recDL/AppDelegate+UI.swift
+++ b/recDL/AppDelegate+UI.swift
@@ -273,9 +273,9 @@ extension AppDelegate {
         // print("\(#file) \(#line) \(#function)")
         
         // Resize Window using specified scale value
-        if let window = parentView.window, let manager = manager {
+        if let window = parentView.window, let manager = manager, let contentView = window.contentView {
             let nativeSize = manager.encodedSize
-            let contentSize = window.contentView!.bounds.size
+            let contentSize = contentView.bounds.size
             let topOffset: CGFloat = window.frame.size.height - contentSize.height
             
             let targetRatio: CGFloat = apertureRatio() * nativeSize.width / nativeSize.height

--- a/recDL/AppDelegate.swift
+++ b/recDL/AppDelegate.swift
@@ -34,6 +34,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     internal var cachedRunningState = false
     internal var recordingStartInProgress = false
     internal var recordingStartTask: Task<Void, Never>? = nil
+    internal var restartSessionTask: Task<Void, Never>? = nil
     internal var terminationInProgress = false
     internal var previewLayerReady : Bool = false
     internal var updateTimer : Timer? = nil
@@ -91,25 +92,32 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             self.cachedRunningState = running
         }
     }
-
+    
+    internal func refreshCachedState() async {
+        let recording = await captureSession.isRecording()
+        let running = await captureSession.isRunning()
+        cachedRecordingState = recording
+        cachedRunningState = running
+    }
+    
     internal var recordingStartPending: Bool {
         recordingStartTask != nil || recordingStartInProgress
     }
-
+    
     private var requiresTerminationCleanup: Bool {
         manager != nil || cachedRecordingState || cachedRunningState || recordingStartPending
     }
-
+    
     private func prepareForTermination() async {
         await recordingStartTask?.value
     }
-
+    
     internal func scheduleRecordingStart(for sec: Int) {
         guard !recordingStartPending else {
             printVerbose("ERROR:\(self.className): \(#function) - Recording start already in progress")
             return
         }
-
+        
         recordingStartTask = Task { @MainActor [weak self] in
             guard let self = self else {
                 AppDelegate.printNilSelfWarning(#function)
@@ -365,7 +373,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                                                             using: handler)
         
         // Initialize cached recording state
-        updateCachedState()
+        await refreshCachedState()
         
         prepared = true
     }

--- a/recDL/AppDelegate.swift
+++ b/recDL/AppDelegate.swift
@@ -35,6 +35,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     internal var recordingStartInProgress = false
     internal var recordingStartTask: Task<Void, Never>? = nil
     internal var restartSessionTask: Task<Void, Never>? = nil
+    internal var setupTask: Task<Void, Never>? = nil
     internal var terminationInProgress = false
     internal var previewLayerReady : Bool = false
     internal var updateTimer : Timer? = nil
@@ -105,13 +106,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
     
     private var requiresTerminationCleanup: Bool {
-        manager != nil || cachedRecordingState || cachedRunningState || recordingStartPending || restartSessionTask != nil
+        manager != nil || cachedRecordingState || cachedRunningState || recordingStartPending || restartSessionTask != nil || setupTask != nil
     }
     
     private func prepareForTermination() async {
         await recordingStartTask?.value
         restartSessionTask?.cancel()
         await restartSessionTask?.value
+        setupTask?.cancel()
+        await setupTask?.value
     }
     
     internal func scheduleRecordingStart(for sec: Int) {
@@ -295,7 +298,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Register defaults
         defaults.register(defaults: keyValues)
         
-        Task { await setup() }
+        setupTask = Task { @MainActor [weak self] in
+            guard let self = self else { return }
+            defer { self.setupTask = nil }
+            await self.setup()
+        }
     }
     
     private func setup() async {
@@ -330,6 +337,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         //
         parentView.verbose = false
         await startSession()
+        guard !Task.isCancelled else { return }
         
         // Update Toolbar button title
         setVolume(-1)                       // Update Popup Menu Selection
@@ -388,7 +396,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             return .terminateLater
         }
         
-        guard prepared else {
+        guard prepared || setupTask != nil else {
             printVerbose("NOTICE:\(self.className): \(#function) - ready")
             return .terminateNow
         }

--- a/recDL/AppDelegate.swift
+++ b/recDL/AppDelegate.swift
@@ -285,10 +285,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Register defaults
         defaults.register(defaults: keyValues)
         
-        Task { setup() }
+        Task { await setup() }
     }
     
-    private func setup() {
+    private func setup() async {
         // print("\(#file) \(#line) \(#function)")
         
         // Register notification observer for Cocoa scripting support
@@ -319,7 +319,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         
         //
         parentView.verbose = false
-        startSession()
+        await startSession()
         
         // Update Toolbar button title
         setVolume(-1)                       // Update Popup Menu Selection
@@ -372,22 +372,22 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     
     public func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         // print("\(#file) \(#line) \(#function)")
-
+        
         guard terminationInProgress == false else {
             printVerbose("NOTICE:\(self.className): \(#function) - cleanup already in progress")
             return .terminateLater
         }
-
+        
         guard prepared else {
             printVerbose("NOTICE:\(self.className): \(#function) - ready")
             return .terminateNow
         }
-
+        
         guard requiresTerminationCleanup else {
             printVerbose("NOTICE:\(self.className): \(#function) - no session cleanup required")
             return .terminateNow
         }
-
+        
         terminationInProgress = true
         Task { @MainActor [weak self] in
             guard let self = self else {
@@ -395,12 +395,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 NSApp.reply(toApplicationShouldTerminate: true)
                 return
             }
-
+            
             printVerbose("NOTICE:\(self.className): \(#function) - cleanup started")
             await prepareForTermination()
-            cleanup()
+            await cleanup()
             printVerbose("NOTICE:\(self.className): \(#function) - cleanup done")
-
+            
             NSApp.reply(toApplicationShouldTerminate: true)
             self.terminationInProgress = false
         }
@@ -414,12 +414,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Force termination handler (NSApplicationDelegate method)
         if prepared {
             printVerbose("NOTICE:\(self.className): \(#function) - cleanup started")
-            cleanup()
+            Task { @MainActor [weak self] in
+                guard let self = self else { return }
+                await cleanup()
+            }
             printVerbose("NOTICE:\(self.className): \(#function) - cleanup done")
         }
     }
     
-    private func cleanup() {
+    private func cleanup() async {
         // print("\(#file) \(#line) \(#function)")
         
         // Ensure that we are prepared
@@ -436,7 +439,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         
         // Stop Session
         removePreviewLayer()
-        stopSession()
+        await stopSession()
         
         // Resign notification observer
         notificationCenter.removeObserver(self)

--- a/recDL/AppDelegate.swift
+++ b/recDL/AppDelegate.swift
@@ -445,8 +445,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Wait for any in-flight session transitions before cleanup
         await prepareForTermination()
         
-        // Ensure that we are prepared
-        if prepared == false { return }
+        // If setup never reached manager creation, there is nothing to tear down.
+        guard manager != nil else { return }
         
         // Reset AppIcon
         NSApp.applicationIconImage = nil

--- a/recDL/AppDelegate.swift
+++ b/recDL/AppDelegate.swift
@@ -110,6 +110,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     
     private func prepareForTermination() async {
         await recordingStartTask?.value
+        restartSessionTask?.cancel()
         await restartSessionTask?.value
     }
     
@@ -406,7 +407,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
             
             printVerbose("NOTICE:\(self.className): \(#function) - cleanup started")
-            await prepareForTermination()
             await cleanup()
             printVerbose("NOTICE:\(self.className): \(#function) - cleanup done")
             

--- a/recDL/AppDelegate.swift
+++ b/recDL/AppDelegate.swift
@@ -451,6 +451,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         
         // Stop Session
         removePreviewLayer()
+        invalidateStopTimer()
         await stopSession()
         
         // Resign notification observer

--- a/recDL/AppDelegate.swift
+++ b/recDL/AppDelegate.swift
@@ -105,11 +105,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
     
     private var requiresTerminationCleanup: Bool {
-        manager != nil || cachedRecordingState || cachedRunningState || recordingStartPending
+        manager != nil || cachedRecordingState || cachedRunningState || recordingStartPending || restartSessionTask != nil
     }
     
     private func prepareForTermination() async {
         await recordingStartTask?.value
+        await restartSessionTask?.value
     }
     
     internal func scheduleRecordingStart(for sec: Int) {
@@ -432,6 +433,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     
     private func cleanup() async {
         // print("\(#file) \(#line) \(#function)")
+        
+        // Wait for any in-flight session transitions before cleanup
+        await prepareForTermination()
         
         // Ensure that we are prepared
         if prepared == false { return }

--- a/recDL/AppDelegate.swift
+++ b/recDL/AppDelegate.swift
@@ -39,6 +39,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     internal var updateTimer : Timer? = nil
     internal var stopTimer : Timer? = nil
     
+    internal var frameObserverToken: (any NSObjectProtocol)? = nil
+    
     internal var evalAutoQuitFlag : Bool = false
     internal var targetPath : String? = nil
     
@@ -357,10 +359,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 await self.updateCurrentScale()
             }
         }
-        notificationCenter.addObserver(forName: NSView.frameDidChangeNotification,
-                                       object: parentView,
-                                       queue: nil,
-                                       using: handler)
+        frameObserverToken = notificationCenter.addObserver(forName: NSView.frameDidChangeNotification,
+                                                            object: parentView,
+                                                            queue: nil,
+                                                            using: handler)
         
         // Initialize cached recording state
         updateCachedState()
@@ -438,6 +440,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         
         // Resign notification observer
         notificationCenter.removeObserver(self)
+        if let token = frameObserverToken {
+            notificationCenter.removeObserver(token)
+            frameObserverToken = nil
+        }
         
         //
         prepared = false

--- a/recDL/AppDelegate.swift
+++ b/recDL/AppDelegate.swift
@@ -451,7 +451,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         
         // Stop Session
         removePreviewLayer()
-        invalidateStopTimer()
         await stopSession()
         
         // Resign notification observer

--- a/recDL/AppDelegate.swift
+++ b/recDL/AppDelegate.swift
@@ -426,8 +426,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             Task { @MainActor [weak self] in
                 guard let self = self else { return }
                 await cleanup()
+                printVerbose("NOTICE:\(self.className): \(#function) - cleanup done")
             }
-            printVerbose("NOTICE:\(self.className): \(#function) - cleanup done")
         }
     }
     


### PR DESCRIPTION
Replays the current work branch into master with the recDL stability fixes.

Highlights:
- remove blocking semaphore behavior from the session flow
- guard restartSession against reentry
- add cleanup ordering and nonblocking teardown fixes
- address cached recording state and cancellation handling in restartSessionTask