### PR TITLE
Prevent main-actor deadlock in performAsync

### DIFF
--- a/Source/AppDelegate+Session.swift
+++ b/Source/AppDelegate+Session.swift
@@ -75,7 +75,8 @@ extension AppDelegate {
     }
     
     /// Executes an asynchronous, throwing operation synchronously.
-    /// - Note: Uses an attached task to avoid detached-task sendability diagnostics.
+    /// - Note: Uses a detached task so the synchronous semaphore wait does not
+    ///   inherit `@MainActor` and deadlock the main thread.
     nonisolated func performAsync<T: Sendable>(_ block: @Sendable @escaping () async throws -> T) throws -> T {
         let box = ThrowingAsyncResultBox<T>()
         
@@ -91,7 +92,8 @@ extension AppDelegate {
     }
     
     /// Executes an asynchronous, non-throwing operation synchronously.
-    /// - Note: Uses an attached task to avoid detached-task sendability diagnostics.
+    /// - Note: Uses a detached task so the synchronous semaphore wait does not
+    ///   inherit `@MainActor` and deadlock the main thread.
     nonisolated func performAsync<T: Sendable>(_ block: @Sendable @escaping () async -> T) -> T {
         let box = AsyncResultBox<T>()
         

--- a/Source/AppDelegate+Session.swift
+++ b/Source/AppDelegate+Session.swift
@@ -79,7 +79,7 @@ extension AppDelegate {
     nonisolated func performAsync<T: Sendable>(_ block: @Sendable @escaping () async throws -> T) throws -> T {
         let box = ThrowingAsyncResultBox<T>()
         
-        Task(priority: .high) { [box, block] in
+        Task.detached(priority: .high) { [box, block] in
             do {
                 box.store(.success(try await block()))
             } catch {
@@ -95,7 +95,7 @@ extension AppDelegate {
     nonisolated func performAsync<T: Sendable>(_ block: @Sendable @escaping () async -> T) -> T {
         let box = AsyncResultBox<T>()
         
-        Task(priority: .high) { [box, block] in
+        Task.detached(priority: .high) { [box, block] in
             box.store(await block())
         }
         
@@ -393,8 +393,9 @@ extension AppDelegate {
             manager.encodeAudioBitrate = 0
         }
         
+        let session = self.captureSession
         performAsync {
-            await self.captureSession.invalidateRecordingPreparation()
+            await session.invalidateRecordingPreparation()
         }
     }
     
@@ -410,8 +411,9 @@ extension AppDelegate {
     public func startRecording(for sec: Int) {
         // print("\(#file) \(#line) \(#function)")
         
+        let session = self.captureSession
         let isRecording = performAsync {
-            await self.captureSession.isRecording()
+            await session.isRecording()
         }
         
         if manager != nil && !isRecording, let movieURL = createMovieURL() {
@@ -420,7 +422,7 @@ extension AppDelegate {
             
             // Start recording to specified URL
             let recordingStarted = performAsync {
-                await self.captureSession.startRecording(to: movieURL)
+                await session.startRecording(to: movieURL)
             }
             
             // Update cached state after operation
@@ -525,15 +527,16 @@ extension AppDelegate {
     public func stopRecording() {
         // print("\(#file) \(#line) \(#function)")
         
+        let session = self.captureSession
         let isRecording = performAsync {
-            await self.captureSession.isRecording()
+            await session.isRecording()
         }
         
         // Stop recording
         if manager != nil && isRecording {
             // Stop recording to specified URL
             let recordingStopped = performAsync {
-                await self.captureSession.stopRecording()
+                await session.stopRecording()
             }
             
             // Update cached state after operation

--- a/Source/AppDelegate.swift
+++ b/Source/AppDelegate.swift
@@ -76,11 +76,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     /* ============================================ */
     
     internal func updateCachedState() {
+        let session = self.captureSession
         cachedRecordingState = performAsync {
-            await self.captureSession.isRecording()
+            await session.isRecording()
         }
         cachedRunningState = performAsync {
-            await self.captureSession.isRunning()
+            await session.isRunning()
         }
     }
     


### PR DESCRIPTION
Fixes CR-6 by moving the synchronous async bridge off the main actor and capturing `captureSession` locally before passing it into `performAsync`.

- switch performAsync to Task.detached
- bind captureSession to a local constant at each call site
- keep the synchronous scripting bridge behavior while avoiding the semaphore/main-actor deadlock path