### PR TITLE
Fix L-01, L-02, L-03, L-04, and L-05 in recDL

### DIFF
--- a/Source/AppDelegate+Session.swift
+++ b/Source/AppDelegate+Session.swift
@@ -292,12 +292,23 @@ extension AppDelegate {
             defer {
                 self.restartSessionTask = nil
             }
+            // Honor cancellation as early as possible so that termination
+            // (which calls `restartSessionTask?.cancel()` then `await`s the
+            // value) does not have to wait for stopSession() to complete.
+            if Task.isCancelled {
+                return
+            }
             // Stop Session
             self.stopUpdateStatus()
             self.defaults.set(false, forKey: Keys.showAlternate)
             
             self.removePreviewLayer()
             self.manager?.videoPreview = nil
+            
+            // Re-check before the expensive async teardown.
+            if Task.isCancelled {
+                return
+            }
             await self.stopSession()
             
             // Honor cancellation before starting a fresh session.

--- a/Source/AppDelegate+Session.swift
+++ b/Source/AppDelegate+Session.swift
@@ -246,9 +246,13 @@ extension AppDelegate {
             // cancellation, so the prewarm body runs to completion
             // regardless. The actual barrier is the
             // `await prewarmTask?.value` below.
-            prewarmTask?.cancel()
-            _ = await prewarmTask?.value
-            prewarmTask = nil
+            let drainingTask = prewarmTask
+            let drainingGeneration = prewarmGeneration
+            drainingTask?.cancel()
+            _ = await drainingTask?.value
+            if prewarmGeneration == drainingGeneration {
+                prewarmTask = nil
+            }
             
             invalidateStopTimer()
             evalAutoQuitFlag = false

--- a/Source/AppDelegate+Session.swift
+++ b/Source/AppDelegate+Session.swift
@@ -187,11 +187,10 @@ extension AppDelegate {
             // Track prewarm Task so stopSession() can wait for it to
             // finish before proceeding with teardown. The actor-side
             // `prewarmInProgress` gate still serializes calls, and
-            // M-11's `waitUntilRecordingIdle()` in `destroyManager()`
-            // already waits for any in-flight prewarm before nil-ing
-            // the manager. Storing the reference here gives stopSession
-            // an earlier, explicit "wait for prewarm to drain" point —
-            // a defense-in-depth layer on top of M-11.
+            // `destroyManager()` also waits for any in-flight prewarm
+            // before clearing the manager. Storing the reference here
+            // gives stopSession an earlier, explicit "wait for prewarm
+            // to drain" point.
             //
             // Note: `prewarmTask?.cancel()` in stopSession sets the
             // Task's cancellation flag, but the actor's
@@ -206,9 +205,9 @@ extension AppDelegate {
             // "current" prewarm. The capture-and-compare pattern against
             // `prewarmGeneration` prevents an old prewarm's nil-out closure
             // from wiping out a newer `prewarmTask` reference that has
-            // since been installed (e.g. a stopSession/startSession cycle
-            // before the old prewarm's MainActor.run fires). See L-01 §1.5
-            // for the exact race scenario.
+            // since been installed (for example, when stopSession and a
+            // subsequent startSession run before the old prewarm's
+            // MainActor.run block executes).
             prewarmGeneration += 1
             let myGeneration = prewarmGeneration
             prewarmTask = Task(priority: .utility) { [captureSession, weak self] in
@@ -236,11 +235,10 @@ extension AppDelegate {
             printVerbose("NOTICE:\(self.className): \(#function) - Stopping capture session...")
             
             // Drain any in-flight prewarm Task before proceeding with
-            // teardown. The actor's `prewarmInProgress` gate + M-11's
-            // `waitUntilRecordingIdle()` in `destroyManager()` will also
-            // drain it, but waiting here is an earlier, explicit
-            // barrier: we don't start `stopCaptureSession` while the
-            // prewarm is still running.
+            // teardown. The actor's `prewarmInProgress` gate and
+            // `destroyManager()` also wait for it, but waiting here is
+            // an earlier, explicit barrier: we do not start
+            // `stopCaptureSession` while the prewarm is still running.
             //
             // The `.cancel()` call sets the Task's cancellation flag as
             // a best-effort signal, but the actor's

--- a/Source/AppDelegate+Session.swift
+++ b/Source/AppDelegate+Session.swift
@@ -184,8 +184,45 @@ extension AppDelegate {
             printVerbose("NOTICE:\(self.className): \(#function) - Starting capture session completed.")
             await refreshCachedState()
             
-            Task(priority: .utility) { [captureSession] in
+            // Track prewarm Task so stopSession() can wait for it to
+            // finish before proceeding with teardown. The actor-side
+            // `prewarmInProgress` gate still serializes calls, and
+            // M-11's `waitUntilRecordingIdle()` in `destroyManager()`
+            // already waits for any in-flight prewarm before nil-ing
+            // the manager. Storing the reference here gives stopSession
+            // an earlier, explicit "wait for prewarm to drain" point —
+            // a defense-in-depth layer on top of M-11.
+            //
+            // Note: `prewarmTask?.cancel()` in stopSession sets the
+            // Task's cancellation flag, but the actor's
+            // `prewarmRecordingPath()` does not currently poll
+            // `Task.isCancelled` / `Task.checkCancellation()`, so the
+            // prewarm body runs to completion regardless. The actual
+            // benefit is the `await prewarmTask?.value` wait, not the
+            // cancel itself.
+            //
+            // On completion (or cancellation) we hop back to the main actor
+            // and clear the property — but only if we are still the
+            // "current" prewarm. The capture-and-compare pattern against
+            // `prewarmGeneration` prevents an old prewarm's nil-out closure
+            // from wiping out a newer `prewarmTask` reference that has
+            // since been installed (e.g. a stopSession/startSession cycle
+            // before the old prewarm's MainActor.run fires). See L-01 §1.5
+            // for the exact race scenario.
+            prewarmGeneration += 1
+            let myGeneration = prewarmGeneration
+            prewarmTask = Task(priority: .utility) { [captureSession, weak self] in
                 _ = await captureSession.prewarmRecordingPath()
+                await MainActor.run {
+                    guard let self else { return }
+                    // Only clear the property if we are still the most
+                    // recent prewarm. A subsequent startSession has
+                    // bumped `prewarmGeneration`, and stopSession has
+                    // already cleared `prewarmTask` to nil; in either
+                    // case we must not touch the property.
+                    guard self.prewarmGeneration == myGeneration else { return }
+                    self.prewarmTask = nil
+                }
             }
         } else {
             printVerbose("ERROR:\(self.className): \(#function) - Starting capture session failed.")
@@ -197,6 +234,24 @@ extension AppDelegate {
         
         if manager != nil {
             printVerbose("NOTICE:\(self.className): \(#function) - Stopping capture session...")
+            
+            // Drain any in-flight prewarm Task before proceeding with
+            // teardown. The actor's `prewarmInProgress` gate + M-11's
+            // `waitUntilRecordingIdle()` in `destroyManager()` will also
+            // drain it, but waiting here is an earlier, explicit
+            // barrier: we don't start `stopCaptureSession` while the
+            // prewarm is still running.
+            //
+            // The `.cancel()` call sets the Task's cancellation flag as
+            // a best-effort signal, but the actor's
+            // `prewarmRecordingPath()` does not currently poll
+            // cancellation, so the prewarm body runs to completion
+            // regardless. The actual barrier is the
+            // `await prewarmTask?.value` below.
+            prewarmTask?.cancel()
+            _ = await prewarmTask?.value
+            prewarmTask = nil
+            
             invalidateStopTimer()
             evalAutoQuitFlag = false
             let result = await self.captureSession.stopCaptureSession()

--- a/Source/AppDelegate.swift
+++ b/Source/AppDelegate.swift
@@ -37,6 +37,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     internal var restartSessionTask: Task<Void, Never>? = nil
     internal var setupTask: Task<Void, Never>? = nil
     internal var terminationTask: Task<Void, Never>? = nil
+    internal var prewarmTask: Task<Void, Never>? = nil
+    /// Monotonic generation counter for `prewarmTask` so that an
+    /// in-flight prewarm Task's completion handler can detect whether
+    /// it is still the "current" prewarm. See L-01 §1.2 and §1.5
+    /// for the race scenario this protects against.
+    internal var prewarmGeneration: Int = 0
     internal var previewLayerReady : Bool = false
     internal var updateTimer : Timer? = nil
     internal var stopTimer : Timer? = nil

--- a/Source/AppDelegate.swift
+++ b/Source/AppDelegate.swift
@@ -40,8 +40,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     internal var prewarmTask: Task<Void, Never>? = nil
     /// Monotonic generation counter for `prewarmTask` so that an
     /// in-flight prewarm Task's completion handler can detect whether
-    /// it is still the "current" prewarm. See L-01 §1.2 and §1.5
-    /// for the race scenario this protects against.
+    /// it is still the current prewarm before clearing the property.
     internal var prewarmGeneration: Int = 0
     internal var previewLayerReady : Bool = false
     internal var updateTimer : Timer? = nil

--- a/Source/PrefController.swift
+++ b/Source/PrefController.swift
@@ -38,6 +38,7 @@ class PrefController: NSViewController {
     @IBOutlet weak var vsErrorLabel: NSTextField!
     @IBOutlet weak var clapErrorLabel: NSTextField!
     @IBOutlet weak var fdErrorLabel: NSTextField!
+    @IBOutlet weak var audioBitRateErrorLabel: NSTextField!
 
     @IBOutlet weak var buttonAudioEncode: NSButton!
     @IBOutlet weak var textAudioBitRate: NSTextField!
@@ -78,7 +79,32 @@ class PrefController: NSViewController {
     }
 
     @IBAction func updateAudioEncoder(_ sender: Any) {
+        // The XIB binds `textAudioBitRate.value` to
+        // `values.audioBitRate`, so by the time this IBAction fires the
+        // (possibly invalid) value has already been written to
+        // `Keys.audioBitRate` via `NSUserDefaultsController`. If we let
+        // an out-of-range value reach `applyRecordingParameters()` (in
+        // `AppDelegate+Session.swift`), the recording pipeline will
+        // happily produce a movie with an invalid AAC bitrate.
+        //
+        // Clamp the value here — both the text field and the defaults
+        // — so the recording pipeline never sees an out-of-range
+        // bitrate. The `adjustAudioEncoder()` call below then maps the
+        // (now in-range) value to the right AAC variant.
+        let kbps = textAudioBitRate.integerValue
+        if kbps < Self.audioBitRateMinKbps || kbps > Self.audioBitRateMaxKbps {
+            let clamped = min(max(kbps, Self.audioBitRateMinKbps), Self.audioBitRateMaxKbps)
+            textAudioBitRate.integerValue = clamped
+            defaults.set(clamped, forKey: Keys.audioBitRate)
+            appDelegate.printVerbose("ERROR:PrefController: \(#function) - Audio bit rate out of range: \(kbps) kbps, clamped to \(clamped) kbps (valid: \(Self.audioBitRateMinKbps)–\(Self.audioBitRateMaxKbps))")
+        }
+        
         adjustAudioEncoder()
+        
+        // Refresh the UI so the error label state reflects the new
+        // value immediately (without this, the user would have to
+        // toggle another control to see the error / non-error state).
+        refreshUI()
     }
     
     @IBAction func restartSession(_ sender: Any) {
@@ -151,6 +177,27 @@ class PrefController: NSViewController {
         vsErrorLabel.isHidden = videoStyleOK
         clapErrorLabel.isHidden = clapOK
         fdErrorLabel.isHidden = fdOK
+        
+        // Defensive guard for an outlet that is added together with the
+        // XIB edit (Step 5.3.2). If the XIB edit and the outlet are
+        // committed separately, the IBOutlet will be nil at runtime
+        // and any access to it would trap. We use `if let` (not an
+        // early `guard let` at the top of the function) so that the
+        // existing 3 error labels above are still updated even when
+        // the audio-bit-rate outlet is unwired — the wiring mismatch
+        // is then limited to "the audio bit rate error message does
+        // not appear", not "all error labels stop working".
+        if let audioBitRateErrorLabel = audioBitRateErrorLabel {
+            // Validate the audio bit rate text field. Mirrors the
+            // range check in `adjustAudioEncoder()` but is decoupled
+            // so the label reflects the current field state even
+            // when the user is mid-edit and the IBAction has not yet
+            // fired.
+            let kbps = textAudioBitRate.integerValue
+            let audioBitRateOK = kbps >= Self.audioBitRateMinKbps
+                && kbps <= Self.audioBitRateMaxKbps
+            audioBitRateErrorLabel.isHidden = audioBitRateOK
+        }
     }
     
     private func updateAudioLayout() {
@@ -159,9 +206,37 @@ class PrefController: NSViewController {
         btnReverse34.isEnabled = audioChannelLayoutOK
     }
     
+    /// Inclusive valid range for the audio bit rate text field, in kbps.
+    /// Chosen to cover all three AAC variants that `applyRecordingParameters()`
+    /// can select (HE-AACv2 ≥ 16, HE-AAC up to 80, AAC LC up to 512).
+    /// Values outside this range are treated as user-input errors and
+    /// suppress the `audioEncoder` defaults update + show an error label.
+    private static let audioBitRateMinKbps: Int = 16
+    private static let audioBitRateMaxKbps: Int = 512
+    
     private func adjustAudioEncoder() {
-        let useAudioBitRateKbps :Int = textAudioBitRate.integerValue
+        let useAudioBitRateKbps: Int = textAudioBitRate.integerValue
         let useAudioBitRate = useAudioBitRateKbps * 1000
+        
+        // Reject out-of-range input (empty, non-numeric → 0, negative,
+        // or absurdly large). The previous implementation silently fell
+        // through to HE-AACv2 in the `else` branch, which would record
+        // near-silent audio with no feedback to the user.
+        if useAudioBitRateKbps < Self.audioBitRateMinKbps
+            || useAudioBitRateKbps > Self.audioBitRateMaxKbps {
+            // Leave the previous valid `audioEncoder` defaults value
+            // untouched and surface the error via the existing label
+            // infrastructure. `refreshUI()` → `updateErrorLabel()`
+            // (see below) takes care of show/hide.
+            //
+            // Note: `printVerbose(_:)` and `className` are defined on
+            // `AppDelegate`, not on `PrefController`. Route the log
+            // through the existing `appDelegate` outlet to keep the
+            // verbose-log formatting consistent with the rest of the
+            // app.
+            appDelegate.printVerbose("ERROR:PrefController: \(#function) - Audio bit rate out of range: \(useAudioBitRateKbps) kbps (valid: \(Self.audioBitRateMinKbps)–\(Self.audioBitRateMaxKbps))")
+            return
+        }
         
         if useAudioBitRate > AudioConstants.aacBitrateThreshold {
             defaults.set(1, forKey: Keys.audioEncoder)

--- a/Source/PrefController.swift
+++ b/Source/PrefController.swift
@@ -39,7 +39,7 @@ class PrefController: NSViewController {
     @IBOutlet weak var clapErrorLabel: NSTextField!
     @IBOutlet weak var fdErrorLabel: NSTextField!
     @IBOutlet weak var audioBitRateErrorLabel: NSTextField!
-
+    
     @IBOutlet weak var buttonAudioEncode: NSButton!
     @IBOutlet weak var textAudioBitRate: NSTextField!
     
@@ -77,7 +77,7 @@ class PrefController: NSViewController {
             refreshUI()
         }
     }
-
+    
     @IBAction func updateAudioEncoder(_ sender: Any) {
         // The XIB binds `textAudioBitRate.value` to
         // `values.audioBitRate`, so by the time this IBAction fires the

--- a/Source/PrefController.swift
+++ b/Source/PrefController.swift
@@ -38,7 +38,7 @@ class PrefController: NSViewController {
     @IBOutlet weak var vsErrorLabel: NSTextField!
     @IBOutlet weak var clapErrorLabel: NSTextField!
     @IBOutlet weak var fdErrorLabel: NSTextField!
-    @IBOutlet weak var audioBitRateErrorLabel: NSTextField!
+    @IBOutlet weak var audioBitRateErrorLabel: NSTextField?
 
     @IBOutlet weak var buttonAudioEncode: NSButton!
     @IBOutlet weak var textAudioBitRate: NSTextField!
@@ -96,7 +96,7 @@ class PrefController: NSViewController {
             let clamped = min(max(kbps, Self.audioBitRateMinKbps), Self.audioBitRateMaxKbps)
             textAudioBitRate.integerValue = clamped
             defaults.set(clamped, forKey: Keys.audioBitRate)
-            appDelegate.printVerbose("ERROR:PrefController: \(#function) - Audio bit rate out of range: \(kbps) kbps, clamped to \(clamped) kbps (valid: \(Self.audioBitRateMinKbps)–\(Self.audioBitRateMaxKbps))")
+            appDelegate.printVerbose("ERROR:\(self.className): \(#function) - Audio bit rate out of range: \(kbps) kbps, clamped to \(clamped) kbps (valid: \(Self.audioBitRateMinKbps)–\(Self.audioBitRateMaxKbps))")
         }
         
         adjustAudioEncoder()
@@ -178,10 +178,10 @@ class PrefController: NSViewController {
         clapErrorLabel.isHidden = clapOK
         fdErrorLabel.isHidden = fdOK
         
-        // Keep the existing error labels updating even if the XIB outlet
-        // for the bitrate indicator is missing or mismatched. In that
-        // case only the audio-bitrate warning is skipped, rather than
-        // disabling every error label in the preferences window.
+        // Keep the existing error labels updating even if the bitrate
+        // indicator outlet is nil at runtime. In that case only the
+        // audio-bitrate warning is skipped, rather than disabling every
+        // error label in the preferences window.
         if let audioBitRateErrorLabel = audioBitRateErrorLabel {
             // Validate the audio bit rate text field. Mirrors the
             // range check in `adjustAudioEncoder()` but is decoupled
@@ -224,12 +224,7 @@ class PrefController: NSViewController {
             // infrastructure. `refreshUI()` → `updateErrorLabel()`
             // (see below) takes care of show/hide.
             //
-            // Note: `printVerbose(_:)` and `className` are defined on
-            // `AppDelegate`, not on `PrefController`. Route the log
-            // through the existing `appDelegate` outlet to keep the
-            // verbose-log formatting consistent with the rest of the
-            // app.
-            appDelegate.printVerbose("ERROR:PrefController: \(#function) - Audio bit rate out of range: \(useAudioBitRateKbps) kbps (valid: \(Self.audioBitRateMinKbps)–\(Self.audioBitRateMaxKbps))")
+            appDelegate.printVerbose("ERROR:\(self.className): \(#function) - Audio bit rate out of range: \(useAudioBitRateKbps) kbps (valid: \(Self.audioBitRateMinKbps)–\(Self.audioBitRateMaxKbps))")
             return
         }
         

--- a/Source/PrefController.swift
+++ b/Source/PrefController.swift
@@ -204,7 +204,7 @@ class PrefController: NSViewController {
             appDelegate.printVerbose("ERROR:\(self.className): \(#function) - Audio bit rate out of range: \(useAudioBitRateKbps) kbps, clamped to \(clamped) kbps (valid: \(Self.audioBitRateMinKbps)–\(Self.audioBitRateMaxKbps))")
         }
         
-        let normalizedAudioBitRate = textAudioBitRate.integerValue * 1000
+        let normalizedAudioBitRate = UInt(textAudioBitRate.integerValue * 1000)
         
         if normalizedAudioBitRate > AudioConstants.aacBitrateThreshold {
             defaults.set(1, forKey: Keys.audioEncoder)

--- a/Source/PrefController.swift
+++ b/Source/PrefController.swift
@@ -38,7 +38,7 @@ class PrefController: NSViewController {
     @IBOutlet weak var vsErrorLabel: NSTextField!
     @IBOutlet weak var clapErrorLabel: NSTextField!
     @IBOutlet weak var fdErrorLabel: NSTextField!
-    @IBOutlet weak var audioBitRateErrorLabel: NSTextField?
+    @IBOutlet weak var audioBitRateErrorLabel: NSTextField!
 
     @IBOutlet weak var buttonAudioEncode: NSButton!
     @IBOutlet weak var textAudioBitRate: NSTextField!
@@ -178,21 +178,14 @@ class PrefController: NSViewController {
         clapErrorLabel.isHidden = clapOK
         fdErrorLabel.isHidden = fdOK
         
-        // Keep the existing error labels updating even if the bitrate
-        // indicator outlet is nil at runtime. In that case only the
-        // audio-bitrate warning is skipped, rather than disabling every
-        // error label in the preferences window.
-        if let audioBitRateErrorLabel = audioBitRateErrorLabel {
-            // Validate the audio bit rate text field. Mirrors the
-            // range check in `adjustAudioEncoder()` but is decoupled
-            // so the label reflects the current field state even
-            // when the user is mid-edit and the IBAction has not yet
-            // fired.
-            let kbps = textAudioBitRate.integerValue
-            let audioBitRateOK = kbps >= Self.audioBitRateMinKbps
-                && kbps <= Self.audioBitRateMaxKbps
-            audioBitRateErrorLabel.isHidden = audioBitRateOK
-        }
+        // Validate the audio bit rate text field. Mirrors the range
+        // check in `adjustAudioEncoder()` but is decoupled so the
+        // label reflects the current field state even when the user
+        // is mid-edit and the IBAction has not yet fired.
+        let kbps = textAudioBitRate.integerValue
+        let audioBitRateOK = kbps >= Self.audioBitRateMinKbps
+            && kbps <= Self.audioBitRateMaxKbps
+        audioBitRateErrorLabel.isHidden = audioBitRateOK
     }
     
     private func updateAudioLayout() {

--- a/Source/PrefController.swift
+++ b/Source/PrefController.swift
@@ -178,15 +178,10 @@ class PrefController: NSViewController {
         clapErrorLabel.isHidden = clapOK
         fdErrorLabel.isHidden = fdOK
         
-        // Defensive guard for an outlet that is added together with the
-        // XIB edit (Step 5.3.2). If the XIB edit and the outlet are
-        // committed separately, the IBOutlet will be nil at runtime
-        // and any access to it would trap. We use `if let` (not an
-        // early `guard let` at the top of the function) so that the
-        // existing 3 error labels above are still updated even when
-        // the audio-bit-rate outlet is unwired — the wiring mismatch
-        // is then limited to "the audio bit rate error message does
-        // not appear", not "all error labels stop working".
+        // Keep the existing error labels updating even if the XIB outlet
+        // for the bitrate indicator is missing or mismatched. In that
+        // case only the audio-bitrate warning is skipped, rather than
+        // disabling every error label in the preferences window.
         if let audioBitRateErrorLabel = audioBitRateErrorLabel {
             // Validate the audio bit rate text field. Mirrors the
             // range check in `adjustAudioEncoder()` but is decoupled
@@ -206,13 +201,13 @@ class PrefController: NSViewController {
         btnReverse34.isEnabled = audioChannelLayoutOK
     }
     
-    /// Inclusive valid range for the audio bit rate text field, in kbps.
-    /// Chosen to cover all three AAC variants that `applyRecordingParameters()`
-    /// can select (HE-AACv2 ≥ 16, HE-AAC up to 80, AAC LC up to 512).
-    /// Values outside this range are treated as user-input errors and
-    /// suppress the `audioEncoder` defaults update + show an error label.
+    /// Inclusive broad valid range for the audio bit rate text field, in kbps.
+    /// This keeps the UI wide enough for the highest AAC LC bitrate accepted
+    /// by the current recording pipeline (7.1 without LFE = 1120 kbps).
+    /// Lower per-layout ceilings are still enforced later by
+    /// `applyRecordingParameters()` via `queryBitrateRange(channelCount:)`.
     private static let audioBitRateMinKbps: Int = 16
-    private static let audioBitRateMaxKbps: Int = 512
+    private static let audioBitRateMaxKbps: Int = 1120
     
     private func adjustAudioEncoder() {
         let useAudioBitRateKbps: Int = textAudioBitRate.integerValue

--- a/Source/PrefController.swift
+++ b/Source/PrefController.swift
@@ -87,18 +87,6 @@ class PrefController: NSViewController {
         // `AppDelegate+Session.swift`), the recording pipeline will
         // happily produce a movie with an invalid AAC bitrate.
         //
-        // Clamp the value here — both the text field and the defaults
-        // — so the recording pipeline never sees an out-of-range
-        // bitrate. The `adjustAudioEncoder()` call below then maps the
-        // (now in-range) value to the right AAC variant.
-        let kbps = textAudioBitRate.integerValue
-        if kbps < Self.audioBitRateMinKbps || kbps > Self.audioBitRateMaxKbps {
-            let clamped = min(max(kbps, Self.audioBitRateMinKbps), Self.audioBitRateMaxKbps)
-            textAudioBitRate.integerValue = clamped
-            defaults.set(clamped, forKey: Keys.audioBitRate)
-            appDelegate.printVerbose("ERROR:\(self.className): \(#function) - Audio bit rate out of range: \(kbps) kbps, clamped to \(clamped) kbps (valid: \(Self.audioBitRateMinKbps)–\(Self.audioBitRateMaxKbps))")
-        }
-        
         adjustAudioEncoder()
         
         // Refresh the UI so the error label state reflects the new
@@ -204,26 +192,23 @@ class PrefController: NSViewController {
     
     private func adjustAudioEncoder() {
         let useAudioBitRateKbps: Int = textAudioBitRate.integerValue
-        let useAudioBitRate = useAudioBitRateKbps * 1000
         
-        // Reject out-of-range input (empty, non-numeric → 0, negative,
-        // or absurdly large). The previous implementation silently fell
-        // through to HE-AACv2 in the `else` branch, which would record
-        // near-silent audio with no feedback to the user.
+        // Clamp out-of-range input (empty, non-numeric → 0, negative,
+        // or absurdly large) back into the supported range before the
+        // value can reach `applyRecordingParameters()`.
         if useAudioBitRateKbps < Self.audioBitRateMinKbps
             || useAudioBitRateKbps > Self.audioBitRateMaxKbps {
-            // Leave the previous valid `audioEncoder` defaults value
-            // untouched and surface the error via the existing label
-            // infrastructure. `refreshUI()` → `updateErrorLabel()`
-            // (see below) takes care of show/hide.
-            //
-            appDelegate.printVerbose("ERROR:\(self.className): \(#function) - Audio bit rate out of range: \(useAudioBitRateKbps) kbps (valid: \(Self.audioBitRateMinKbps)–\(Self.audioBitRateMaxKbps))")
-            return
+            let clamped = min(max(useAudioBitRateKbps, Self.audioBitRateMinKbps), Self.audioBitRateMaxKbps)
+            textAudioBitRate.integerValue = clamped
+            defaults.set(clamped, forKey: Keys.audioBitRate)
+            appDelegate.printVerbose("ERROR:\(self.className): \(#function) - Audio bit rate out of range: \(useAudioBitRateKbps) kbps, clamped to \(clamped) kbps (valid: \(Self.audioBitRateMinKbps)–\(Self.audioBitRateMaxKbps))")
         }
         
-        if useAudioBitRate > AudioConstants.aacBitrateThreshold {
+        let normalizedAudioBitRate = textAudioBitRate.integerValue * 1000
+        
+        if normalizedAudioBitRate > AudioConstants.aacBitrateThreshold {
             defaults.set(1, forKey: Keys.audioEncoder)
-        } else if useAudioBitRate > AudioConstants.aacHEBitrateThreshold {
+        } else if normalizedAudioBitRate > AudioConstants.aacHEBitrateThreshold {
             defaults.set(2, forKey: Keys.audioEncoder)
         } else {
             defaults.set(3, forKey: Keys.audioEncoder)

--- a/Source/Scripting Support/RDL1Recording.swift
+++ b/Source/Scripting Support/RDL1Recording.swift
@@ -99,4 +99,14 @@ class RDL1Recording: RDL1ScriptableObject {
                                        name: .recordingStoppedNotificationKey,
                                        object: nil)
     }
+    
+    /// Deregister from `NotificationCenter` on deallocation.
+    /// `addObserver(_:selector:name:object:)` does not return a token;
+    /// `removeObserver(self)` removes both observers registered in
+    /// `init()` (started / stopped). The `deinit` is `nonisolated`
+    /// because `@MainActor` types require that form, and
+    /// `removeObserver(_:)` is thread-safe per Foundation's contract.
+    nonisolated deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
 }

--- a/Source/Scripting Support/RDL1ScriptableObject.swift
+++ b/Source/Scripting Support/RDL1ScriptableObject.swift
@@ -41,6 +41,9 @@ class RDL1ScriptableObject: NSObject {
     }
     
     private func objectSpecifierCore() -> ObjectSpecifierBox {
+        guard let container else {
+            return ObjectSpecifierBox(specifier: nil)
+        }
         // `classDescription` is declared non-optional in the AppKit
         // bridge but the actual returned object must be an
         // NSScriptClassDescription to build a property specifier.

--- a/Source/Scripting Support/RDL1ScriptableObject.swift
+++ b/Source/Scripting Support/RDL1ScriptableObject.swift
@@ -41,7 +41,18 @@ class RDL1ScriptableObject: NSObject {
     }
     
     private func objectSpecifierCore() -> ObjectSpecifierBox {
-        let desc = container.classDescription as! NSScriptClassDescription
+        // `classDescription` is declared non-optional in the AppKit
+        // bridge but the actual returned object must be an
+        // NSScriptClassDescription to build a property specifier.
+        // Force-casting (`as!`) would crash if the container's class
+        // description were ever something else (e.g. an sdef mismatch
+        // during scripting reload). Fall back to a nil specifier in
+        // that defensive path so the failure surfaces as a "no
+        // object specifier" to the scripting runtime rather than a
+        // hard crash.
+        guard let desc = container.classDescription as? NSScriptClassDescription else {
+            return ObjectSpecifierBox(specifier: nil)
+        }
         let spec = (container == NSApp) ? nil : container.objectSpecifier
         let prop = containerProperty
         let specifier = NSPropertySpecifier(containerClassDescription: desc,

--- a/Source/Scripting Support/RDL1Session.swift
+++ b/Source/Scripting Support/RDL1Session.swift
@@ -80,4 +80,17 @@ class RDL1Session: RDL1ScriptableObject {
                                        name: .restartSessionNotificationKey,
                                        object: nil)
     }
+    
+    /// Deregister from `NotificationCenter` on deallocation.
+    /// `addObserver(_:selector:name:object:)` does not return a token;
+    /// the standard cleanup for the selector-based API is
+    /// `removeObserver(_:)` (which removes every entry registered
+    /// against `self`). This class only registers its own observer in
+    /// `init()`, so `removeObserver(self)` is exactly equivalent to
+    /// per-token removal. The `deinit` is `nonisolated` because
+    /// `@MainActor` types require that form, and `removeObserver(_:)`
+    /// is thread-safe per Foundation's contract.
+    nonisolated deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
 }

--- a/recDL/Base.lproj/MainMenu.xib
+++ b/recDL/Base.lproj/MainMenu.xib
@@ -31,6 +31,7 @@
         <viewController id="d3T-ds-NJz" customClass="PrefController" customModule="recDL" customModuleProvider="target">
             <connections>
                 <outlet property="appDelegate" destination="Voe-Tx-rLC" id="7qQ-tf-YdA"/>
+                <outlet property="audioBitRateErrorLabel" destination="5tJ-Ep-bLi" id="qge-GV-b6v"/>
                 <outlet property="btnAudioConnection" destination="AfU-p5-UXh" id="Aq7-uw-Bk7"/>
                 <outlet property="btnDisplayMode" destination="5Uz-vZ-I0V" id="3nr-BA-YTa"/>
                 <outlet property="btnRestartSession" destination="Q92-gt-71i" id="mHe-hU-8Ld"/>
@@ -1482,8 +1483,8 @@
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="right" placeholderString="256" drawsBackground="YES" id="2Wp-vA-U14">
                                                             <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" usesGroupingSeparator="NO" groupingSize="0" minimumIntegerDigits="0" maximumIntegerDigits="42" id="RTW-tU-lMq">
-                                                                <real key="minimum" value="32"/>
-                                                                <real key="maximum" value="960"/>
+                                                                <real key="minimum" value="16"/>
+                                                                <real key="maximum" value="512"/>
                                                             </numberFormatter>
                                                             <font key="font" metaFont="miniSystem"/>
                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -1510,6 +1511,15 @@
                                                             <binding destination="aeJ-nD-3pN" name="value" keyPath="values.audioEncode" id="DEl-Yy-JJA"/>
                                                         </connections>
                                                     </button>
+                                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5tJ-Ep-bLi">
+                                                        <rect key="frame" x="200" y="34" width="12" height="11"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" controlSize="mini" lineBreakMode="clipping" alignment="center" title="!" drawsBackground="YES" id="3Rk-2D-j2E">
+                                                            <font key="font" metaFont="menu" size="9"/>
+                                                            <color key="textColor" name="systemRedColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="findHighlightColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
                                                 </subviews>
                                             </view>
                                         </box>

--- a/recDL/Base.lproj/MainMenu.xib
+++ b/recDL/Base.lproj/MainMenu.xib
@@ -954,18 +954,18 @@
                         <tabViewItems>
                             <tabViewItem label="Device" identifier="" id="XQt-zs-a2g">
                                 <view key="view" id="Thu-S3-3ze">
-                                    <rect key="frame" x="10" y="25" width="272" height="503"/>
+                                    <rect key="frame" x="10" y="29" width="272" height="499"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <box fixedFrame="YES" title="DeckLink Device:" translatesAutoresizingMaskIntoConstraints="NO" id="16a-sP-0kh">
-                                            <rect key="frame" x="6" y="280" width="260" height="217"/>
+                                            <rect key="frame" x="6" y="280" width="260" height="213"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <view key="contentView" id="crz-sY-M5s">
-                                                <rect key="frame" x="0.0" y="0.0" width="260" height="205"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="260" height="201"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="JWv-8g-Pt5">
-                                                        <rect key="frame" x="18" y="168" width="88" height="11"/>
+                                                        <rect key="frame" x="18" y="164" width="88" height="11"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="DisplayMode:" id="gyy-Pp-sBU">
                                                             <font key="font" metaFont="miniSystem"/>
@@ -974,7 +974,7 @@
                                                         </textFieldCell>
                                                     </textField>
                                                     <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ri3-0X-Dhn">
-                                                        <rect key="frame" x="18" y="98" width="88" height="11"/>
+                                                        <rect key="frame" x="18" y="94" width="88" height="11"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Audio Connection:" id="6Ad-34-IOt">
                                                             <font key="font" metaFont="miniSystem"/>
@@ -983,7 +983,7 @@
                                                         </textFieldCell>
                                                     </textField>
                                                     <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Q92-gt-71i">
-                                                        <rect key="frame" x="122" y="20" width="118" height="27"/>
+                                                        <rect key="frame" x="122" y="16" width="118" height="27"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <buttonCell key="cell" type="push" title="Restart Session" bezelStyle="rounded" alignment="center" controlSize="small" lineBreakMode="truncatingTail" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Dez-cg-ytV">
                                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -994,7 +994,7 @@
                                                         </connections>
                                                     </button>
                                                     <segmentedControl verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="N68-3E-UDe">
-                                                        <rect key="frame" x="29" y="72" width="75" height="16"/>
+                                                        <rect key="frame" x="29" y="68" width="75" height="16"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <segmentedCell key="cell" controlSize="mini" borderStyle="border" alignment="left" style="rounded" trackingMode="selectOne" id="qA5-BN-lFO">
                                                             <font key="font" metaFont="miniSystem"/>
@@ -1008,7 +1008,7 @@
                                                         </connections>
                                                     </segmentedControl>
                                                     <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Zfl-rF-ROD">
-                                                        <rect key="frame" x="20" y="27" width="94" height="12"/>
+                                                        <rect key="frame" x="20" y="23" width="94" height="12"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <buttonCell key="cell" type="check" title="Reverse 3/4ch" bezelStyle="regularSquare" imagePosition="left" controlSize="mini" inset="2" id="XVR-zx-0QG">
                                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -1019,7 +1019,7 @@
                                                         </connections>
                                                     </button>
                                                     <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UQI-f3-6FZ">
-                                                        <rect key="frame" x="18" y="143" width="88" height="11"/>
+                                                        <rect key="frame" x="18" y="139" width="88" height="11"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Video Connection:" id="WHH-y5-l9f">
                                                             <font key="font" metaFont="miniSystem"/>
@@ -1028,7 +1028,7 @@
                                                         </textFieldCell>
                                                     </textField>
                                                     <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5Uz-vZ-I0V">
-                                                        <rect key="frame" x="112" y="163" width="128" height="22"/>
+                                                        <rect key="frame" x="112" y="159" width="128" height="22"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <popUpButtonCell key="cell" type="push" title="Item 1" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="Ajm-o2-WRr" id="77m-wW-PTy">
                                                             <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -1048,7 +1048,7 @@
                                                         </connections>
                                                     </popUpButton>
                                                     <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CnT-3R-ghG">
-                                                        <rect key="frame" x="112" y="138" width="128" height="22"/>
+                                                        <rect key="frame" x="112" y="134" width="128" height="22"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <popUpButtonCell key="cell" type="push" title="Unspecified" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="rOO-hI-l7B" id="qLS-Kv-FJT">
                                                             <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -1083,7 +1083,7 @@
                                                         </connections>
                                                     </popUpButton>
                                                     <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="AfU-p5-UXh">
-                                                        <rect key="frame" x="112" y="92" width="128" height="22"/>
+                                                        <rect key="frame" x="112" y="88" width="128" height="22"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <popUpButtonCell key="cell" type="push" title="Unspecified" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="lE6-OS-JTC" id="C5P-uA-BmW">
                                                             <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -1118,7 +1118,7 @@
                                                         </connections>
                                                     </popUpButton>
                                                     <segmentedControl verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="QXS-bu-8qk">
-                                                        <rect key="frame" x="112" y="72" width="128" height="16"/>
+                                                        <rect key="frame" x="112" y="68" width="128" height="16"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <segmentedCell key="cell" controlSize="mini" borderStyle="border" alignment="left" segmentDistribution="fillProportionally" style="rounded" trackingMode="selectOne" id="Zt5-N2-8jG">
                                                             <font key="font" metaFont="miniSystem"/>
@@ -1135,7 +1135,7 @@
                                                         </connections>
                                                     </segmentedControl>
                                                     <segmentedControl verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="swG-pf-7ZP">
-                                                        <rect key="frame" x="45" y="51" width="195" height="16"/>
+                                                        <rect key="frame" x="45" y="47" width="195" height="16"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <segmentedCell key="cell" controlSize="mini" borderStyle="border" alignment="left" segmentDistribution="fillProportionally" style="rounded" trackingMode="selectOne" id="xA1-mn-uFb">
                                                             <font key="font" metaFont="miniSystem"/>
@@ -1153,7 +1153,7 @@
                                                         </connections>
                                                     </segmentedControl>
                                                     <segmentedControl verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lRY-c1-avT">
-                                                        <rect key="frame" x="96" y="118" width="144" height="16"/>
+                                                        <rect key="frame" x="96" y="114" width="144" height="16"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <segmentedCell key="cell" controlSize="mini" borderStyle="border" alignment="left" segmentDistribution="fillProportionally" style="rounded" trackingMode="selectOne" id="L8Z-Gx-bpr">
                                                             <font key="font" metaFont="miniSystem"/>
@@ -1170,18 +1170,18 @@
                                             </view>
                                         </box>
                                         <scrollView fixedFrame="YES" borderType="line" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rTk-Wh-Xys">
-                                            <rect key="frame" x="9" y="9" width="254" height="109"/>
+                                            <rect key="frame" x="9" y="9" width="254" height="105"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="U4k-sH-mV0">
-                                                <rect key="frame" x="1" y="1" width="239" height="107"/>
+                                                <rect key="frame" x="1" y="1" width="239" height="103"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <textView editable="NO" importsGraphics="NO" richText="NO" verticallyResizable="YES" findStyle="bar" spellingCorrection="YES" smartInsertDelete="YES" id="YHW-bt-AYE">
-                                                        <rect key="frame" x="0.0" y="0.0" width="239" height="107"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="239" height="103"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                         <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="windowBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                        <size key="minSize" width="239" height="107"/>
+                                                        <size key="minSize" width="239" height="103"/>
                                                         <size key="maxSize" width="254" height="10000000"/>
                                                         <color key="insertionPointColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                                     </textView>
@@ -1192,19 +1192,19 @@
                                                 <autoresizingMask key="autoresizingMask"/>
                                             </scroller>
                                             <scroller key="verticalScroller" verticalHuggingPriority="750" controlSize="small" horizontal="NO" id="tQW-Pw-UK1">
-                                                <rect key="frame" x="240" y="1" width="13" height="107"/>
+                                                <rect key="frame" x="240" y="1" width="13" height="103"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                             </scroller>
                                         </scrollView>
                                         <box fixedFrame="YES" borderType="line" title="Video Style:" translatesAutoresizingMaskIntoConstraints="NO" id="gaG-4t-l0E">
-                                            <rect key="frame" x="6" y="126" width="260" height="150"/>
+                                            <rect key="frame" x="6" y="126" width="260" height="146"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <view key="contentView" id="oZ0-48-KWi">
-                                                <rect key="frame" x="0.0" y="0.0" width="260" height="138"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="260" height="134"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MQl-4u-5qe">
-                                                        <rect key="frame" x="18" y="53" width="148" height="11"/>
+                                                        <rect key="frame" x="18" y="49" width="148" height="11"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Clean Aperture (H, V):" id="M3n-Dh-GRg">
                                                             <font key="font" metaFont="miniSystem"/>
@@ -1213,7 +1213,7 @@
                                                         </textFieldCell>
                                                     </textField>
                                                     <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kDJ-Rw-WTB">
-                                                        <rect key="frame" x="18" y="101" width="82" height="11"/>
+                                                        <rect key="frame" x="18" y="97" width="82" height="11"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Video Style:" id="Jzb-Aj-m6Y">
                                                             <font key="font" metaFont="miniSystem"/>
@@ -1222,7 +1222,7 @@
                                                         </textFieldCell>
                                                     </textField>
                                                     <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mHI-Ay-rNW">
-                                                        <rect key="frame" x="106" y="96" width="134" height="22"/>
+                                                        <rect key="frame" x="106" y="92" width="134" height="22"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <popUpButtonCell key="cell" type="push" title="SD 640:480 Full" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="1001" imageScaling="proportionallyDown" inset="2" selectedItem="96y-oI-P5M" id="Drf-k7-5ua">
                                                             <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -1335,7 +1335,7 @@
                                                         </connections>
                                                     </popUpButton>
                                                     <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VFF-yX-rVv">
-                                                        <rect key="frame" x="244" y="54" width="12" height="11"/>
+                                                        <rect key="frame" x="244" y="50" width="12" height="11"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <textFieldCell key="cell" controlSize="mini" lineBreakMode="clipping" alignment="center" title="!" drawsBackground="YES" id="dJ0-jD-xWL">
                                                             <font key="font" metaFont="menu" size="9"/>
@@ -1344,7 +1344,7 @@
                                                         </textFieldCell>
                                                     </textField>
                                                     <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cPP-7O-3Ki" userLabel="clapOffsetH">
-                                                        <rect key="frame" x="172" y="50" width="30" height="19"/>
+                                                        <rect key="frame" x="172" y="46" width="30" height="19"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="right" placeholderString="0" drawsBackground="YES" id="FQF-o2-Ctm">
                                                             <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="jkb-gi-EBp">
@@ -1365,7 +1365,7 @@
                                                         </connections>
                                                     </textField>
                                                     <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IGH-pT-L3K">
-                                                        <rect key="frame" x="244" y="102" width="12" height="11"/>
+                                                        <rect key="frame" x="244" y="98" width="12" height="11"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <textFieldCell key="cell" controlSize="mini" lineBreakMode="clipping" alignment="center" title="!" drawsBackground="YES" id="omr-go-Exj">
                                                             <font key="font" metaFont="menu" size="9"/>
@@ -1374,7 +1374,7 @@
                                                         </textFieldCell>
                                                     </textField>
                                                     <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3e1-Rf-v6W">
-                                                        <rect key="frame" x="124" y="72" width="116" height="22"/>
+                                                        <rect key="frame" x="124" y="68" width="116" height="22"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <popUpButtonCell key="cell" type="push" title="Progressive" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="EPG-3N-6uX" id="G56-RV-H57">
                                                             <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -1393,7 +1393,7 @@
                                                         </connections>
                                                     </popUpButton>
                                                     <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MGL-L4-MXi">
-                                                        <rect key="frame" x="244" y="78" width="12" height="11"/>
+                                                        <rect key="frame" x="244" y="74" width="12" height="11"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <textFieldCell key="cell" controlSize="mini" lineBreakMode="clipping" alignment="center" title="!" drawsBackground="YES" id="6GH-DQ-hwz">
                                                             <font key="font" metaFont="menu" size="9"/>
@@ -1402,7 +1402,7 @@
                                                         </textFieldCell>
                                                     </textField>
                                                     <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ILj-P8-OxH">
-                                                        <rect key="frame" x="115" y="15" width="125" height="27"/>
+                                                        <rect key="frame" x="115" y="11" width="125" height="27"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <buttonCell key="cell" type="push" title="Adjust VideoStyle" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="bwF-iT-Gta">
                                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -1413,7 +1413,7 @@
                                                         </connections>
                                                     </button>
                                                     <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MEJ-aE-X8v" userLabel="clapOffsetV">
-                                                        <rect key="frame" x="210" y="50" width="30" height="19"/>
+                                                        <rect key="frame" x="210" y="46" width="30" height="19"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="right" placeholderString="0" drawsBackground="YES" id="Cjg-ba-x2J">
                                                             <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="p3w-Ix-4Ax">
@@ -1434,7 +1434,7 @@
                                                         </connections>
                                                     </textField>
                                                     <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="T3P-fL-7kb">
-                                                        <rect key="frame" x="18" y="77" width="100" height="11"/>
+                                                        <rect key="frame" x="18" y="73" width="100" height="11"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Field Dominance:" id="hpm-MD-o0W">
                                                             <font key="font" metaFont="miniSystem"/>

--- a/recDL/Base.lproj/MainMenu.xib
+++ b/recDL/Base.lproj/MainMenu.xib
@@ -1484,7 +1484,7 @@
                                                         <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="right" placeholderString="256" drawsBackground="YES" id="2Wp-vA-U14">
                                                             <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" usesGroupingSeparator="NO" groupingSize="0" minimumIntegerDigits="0" maximumIntegerDigits="42" id="RTW-tU-lMq">
                                                                 <real key="minimum" value="16"/>
-                                                                <real key="maximum" value="512"/>
+                                                                <real key="maximum" value="1120"/>
                                                             </numberFormatter>
                                                             <font key="font" metaFont="miniSystem"/>
                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>


### PR DESCRIPTION
## Summary
- track the prewarm task with a generation counter and wait for it during session stop
- add early cancellation exits in restartSession and remove scripting observers in nonisolated deinits
- replace the force-cast in the scripting object specifier path with a guarded cast
- validate audio bitrate input, clamp invalid values, and align the XIB formatter and warning indicator

## Validation
- xcodebuild -workspace "../DLAB Workspace.xcworkspace" -scheme recDL -configuration Debug -sdk macosx -destination "platform=macOS" clean build
- xcodebuild -workspace "../DLAB Workspace.xcworkspace" -scheme recDL -configuration Debug -sdk macosx -destination "platform=macOS" clean analyze