### PR TITLE
Merge S-01 and S-02 fixes into work

### DIFF
--- a/Source/AppDelegate.swift
+++ b/Source/AppDelegate.swift
@@ -88,6 +88,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         return (recording, running)
     }
 
+    private func applyCachedState(
+        _ state: (recording: Bool, running: Bool)
+    ) {
+        cachedRecordingState = state.recording
+        cachedRunningState = state.running
+    }
+
     /// Sync variant for AppleScript / script callers that need a synchronous
     /// return value. Bridges the async capture-session reads via the
     /// `performAsync` semaphore helper, then assigns the cached fields on the
@@ -98,8 +105,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let state = performAsync {
             await Self.readCachedState(from: session)
         }
-        cachedRecordingState = state.recording
-        cachedRunningState = state.running
+        applyCachedState(state)
     }
 
     /// Fire-and-forget variant for use in `defer` blocks of async functions
@@ -122,11 +128,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     /// from a semaphore-backed `performAsync` call.
     ///
     /// To add a new cached field, update the shared
-    /// `readCachedState(from:)` helper and the assignments in this method.
+    /// `readCachedState(from:)` and `applyCachedState(_:)` helpers.
     internal func refreshCachedState() async {
         let state = await Self.readCachedState(from: captureSession)
-        cachedRecordingState = state.recording
-        cachedRunningState = state.running
+        applyCachedState(state)
     }
     
     internal var recordingStartPending: Bool {

--- a/Source/AppDelegate.swift
+++ b/Source/AppDelegate.swift
@@ -80,14 +80,26 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - Cached State Management
     /* ============================================ */
     
+    private nonisolated static func readCachedState(
+        from session: CaptureSession
+    ) async -> (recording: Bool, running: Bool) {
+        let recording = await session.isRecording()
+        let running = await session.isRunning()
+        return (recording, running)
+    }
+
     /// Sync variant for AppleScript / script callers that need a synchronous
-    /// return value. Bridges the async `refreshCachedState()` via the
-    /// `performAsync` semaphore helper. Use this only from a sync context
-    /// (`@objc public func startRecording(for:)`, etc.).
+    /// return value. Bridges the async capture-session reads via the
+    /// `performAsync` semaphore helper, then assigns the cached fields on the
+    /// main actor. Use this only from a sync context (`@objc public func
+    /// startRecording(for:)`, etc.).
     internal func updateCachedState() {
-        performAsync {
-            await self.refreshCachedState()
+        let session = captureSession
+        let state = performAsync {
+            await Self.readCachedState(from: session)
         }
+        cachedRecordingState = state.recording
+        cachedRunningState = state.running
     }
 
     /// Fire-and-forget variant for use in `defer` blocks of async functions
@@ -105,16 +117,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     /// back-to-back in a single async context, then assigns the cached
     /// fields. The two reads are no longer split across independent
     /// `Task.detached` invocations, so the skew window between them is
-    /// essentially eliminated. All other variants (`updateCachedState()`,
-    /// `updateCachedStateAsync()`) are thin wrappers that adapt this
-    /// method to their calling context.
+    /// essentially eliminated. The sync variant uses the same
+    /// `readCachedState(from:)` helper to avoid re-entering the main actor
+    /// from a semaphore-backed `performAsync` call.
     ///
     /// To add a new cached field, update this method only.
     internal func refreshCachedState() async {
-        let recording = await captureSession.isRecording()
-        let running = await captureSession.isRunning()
-        cachedRecordingState = recording
-        cachedRunningState = running
+        let state = await Self.readCachedState(from: captureSession)
+        cachedRecordingState = state.recording
+        cachedRunningState = state.running
     }
     
     internal var recordingStartPending: Bool {

--- a/Source/AppDelegate.swift
+++ b/Source/AppDelegate.swift
@@ -172,6 +172,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
     
+    // App-lifetime singletons. The classes are explicitly designed for
+    // single-instance use (see class-level doc on RDL1Session /
+    // RDL1Recording); constructing additional instances would cause
+    // duplicate observer registration, leading to duplicate notification
+    // dispatches. The computed `get` is intentionally read-only (no `set`).
     private lazy var _sessionItem :RDL1Session = RDL1Session()
     public var sessionItem :RDL1Session? {
         get { return _sessionItem }

--- a/Source/AppDelegate.swift
+++ b/Source/AppDelegate.swift
@@ -121,7 +121,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     /// `readCachedState(from:)` helper to avoid re-entering the main actor
     /// from a semaphore-backed `performAsync` call.
     ///
-    /// To add a new cached field, update this method only.
+    /// To add a new cached field, update the shared
+    /// `readCachedState(from:)` helper and the assignments in this method.
     internal func refreshCachedState() async {
         let state = await Self.readCachedState(from: captureSession)
         cachedRecordingState = state.recording

--- a/Source/AppDelegate.swift
+++ b/Source/AppDelegate.swift
@@ -80,26 +80,36 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - Cached State Management
     /* ============================================ */
     
+    /// Sync variant for AppleScript / script callers that need a synchronous
+    /// return value. Bridges the async `refreshCachedState()` via the
+    /// `performAsync` semaphore helper. Use this only from a sync context
+    /// (`@objc public func startRecording(for:)`, etc.).
     internal func updateCachedState() {
-        let session = self.captureSession
-        cachedRecordingState = performAsync {
-            await session.isRecording()
-        }
-        cachedRunningState = performAsync {
-            await session.isRunning()
+        performAsync {
+            await self.refreshCachedState()
         }
     }
-    
+
+    /// Fire-and-forget variant for use in `defer` blocks of async functions
+    /// where the caller cannot await the refresh. Internally awaits
+    /// `refreshCachedState()` (the single source of truth).
     internal func updateCachedStateAsync() {
         Task(priority: .utility) { @MainActor [weak self] in
-            guard let self = self else { return }
-            let recording = await self.captureSession.isRecording()
-            let running = await self.captureSession.isRunning()
-            self.cachedRecordingState = recording
-            self.cachedRunningState = running
+            await self?.refreshCachedState()
         }
     }
-    
+
+    /// Single source of truth for cached session state.
+    ///
+    /// Reads `isRecording()` and `isRunning()` from the capture session
+    /// back-to-back in a single async context, then assigns the cached
+    /// fields. The two reads are no longer split across independent
+    /// `Task.detached` invocations, so the skew window between them is
+    /// essentially eliminated. All other variants (`updateCachedState()`,
+    /// `updateCachedStateAsync()`) are thin wrappers that adapt this
+    /// method to their calling context.
+    ///
+    /// To add a new cached field, update this method only.
     internal func refreshCachedState() async {
         let recording = await captureSession.isRecording()
         let running = await captureSession.isRunning()

--- a/Source/Scripting Support/RDL1Recording.swift
+++ b/Source/Scripting Support/RDL1Recording.swift
@@ -11,6 +11,19 @@
 import Cocoa
 @preconcurrency import DLABridging
 
+/// AppleScript-visible `recording` element (singleton).
+///
+/// - **Lifecycle policy (app-lifetime singleton):** A single instance is
+///   held by `AppDelegate._recordingItem` (a `private lazy var`) and
+///   exposed read-only through `AppDelegate.recordingItem`. Constructing
+///   additional instances is unsupported: each new instance would
+///   register additional observers for `recordingStarted` /
+///   `recordingStopped` notification keys, leading to duplicate
+///   observer dispatches (and the AppleScript scripting model assumes
+///   a single `recording` entity per process). The class is never released
+///   during the app's lifetime; therefore the
+///   `nonisolated deinit { removeObserver(self) }` below is a
+///   **defense-in-depth** safety net, not an expected cleanup path.
 @objcMembers
 @MainActor
 class RDL1Recording: RDL1ScriptableObject {
@@ -101,6 +114,12 @@ class RDL1Recording: RDL1ScriptableObject {
     }
     
     /// Deregister from `NotificationCenter` on deallocation.
+    ///
+    /// **Note:** As an app-lifetime singleton (see class doc), this
+    /// `deinit` is **defense-in-depth** — it is not reached during normal
+    /// app execution. It exists to keep the class safe if the lifecycle
+    /// policy is ever changed.
+    ///
     /// `addObserver(_:selector:name:object:)` does not return a token;
     /// `removeObserver(self)` removes both observers registered in
     /// `init()` (started / stopped). The `deinit` is `nonisolated`

--- a/Source/Scripting Support/RDL1Recording.swift
+++ b/Source/Scripting Support/RDL1Recording.swift
@@ -17,10 +17,11 @@ import Cocoa
 ///   held by `AppDelegate._recordingItem` (a `private lazy var`) and
 ///   exposed read-only through `AppDelegate.recordingItem`. Constructing
 ///   additional instances is unsupported: each new instance would
-///   register additional observers for `recordingStarted` /
-///   `recordingStopped` notification keys, leading to duplicate
-///   observer dispatches (and the AppleScript scripting model assumes
-///   a single `recording` entity per process). The class is never released
+///   register additional observers for
+///   `recordingStartedNotificationKey` /
+///   `recordingStoppedNotificationKey`, leading to duplicate observer
+///   dispatches (and the AppleScript scripting model assumes a single
+///   `recording` entity per process). The class is never released
 ///   during the app's lifetime; therefore the
 ///   `nonisolated deinit { removeObserver(self) }` below is a
 ///   **defense-in-depth** safety net, not an expected cleanup path.

--- a/Source/Scripting Support/RDL1Session.swift
+++ b/Source/Scripting Support/RDL1Session.swift
@@ -11,6 +11,18 @@
 import Cocoa
 @preconcurrency import DLABridging
 
+/// AppleScript-visible `session` element (singleton).
+///
+/// - **Lifecycle policy (app-lifetime singleton):** A single instance is
+///   held by `AppDelegate._sessionItem` (a `private lazy var`) and exposed
+///   read-only through `AppDelegate.sessionItem`. Constructing additional
+///   instances is unsupported: each new instance would register an
+///   additional observer for `restartSessionNotificationKey`, leading
+///   to duplicate observer dispatches (and the AppleScript scripting
+///   model assumes a single `session` entity per process). The class is
+///   never released during the app's lifetime; therefore the
+///   `nonisolated deinit { removeObserver(self) }` below is a
+///   **defense-in-depth** safety net, not an expected cleanup path.
 @objcMembers
 @MainActor
 class RDL1Session: RDL1ScriptableObject {
@@ -82,6 +94,12 @@ class RDL1Session: RDL1ScriptableObject {
     }
     
     /// Deregister from `NotificationCenter` on deallocation.
+    ///
+    /// **Note:** As an app-lifetime singleton (see class doc), this
+    /// `deinit` is **defense-in-depth** — it is not reached during normal
+    /// app execution. It exists to keep the class safe if the lifecycle
+    /// policy is ever changed.
+    ///
     /// `addObserver(_:selector:name:object:)` does not return a token;
     /// the standard cleanup for the selector-based API is
     /// `removeObserver(_:)` (which removes every entry registered


### PR DESCRIPTION
This PR integrates the following fixes:
- S-01: Consolidate updateCachedState variants on refreshCachedState() async
- S-02: Document app-lifetime lifecycle policy for RDL1Session and RDL1Recording