### PR TITLE
Adopt AsyncBridge (§10.2) in recDL

### DIFF
--- a/Source/AppDelegate+Session.swift
+++ b/Source/AppDelegate+Session.swift
@@ -30,7 +30,11 @@ extension AppDelegate {
     
     /// Executes an asynchronous, non-throwing operation synchronously.
     /// - Note: A `() async -> T` block satisfies `() async throws -> T`,
-    ///   so the throwing variant of `AsyncBridge.perform` is reused.
+    ///   so the throwing variant of `AsyncBridge.perform` is reused. The
+    ///   `catch` is intentionally fatal: a non-throwing block cannot
+    ///   produce a `PerformAsyncError` (.timeout / .operationFailed) under
+    ///   normal operation, so reaching it indicates an internal bridge
+    ///   bug rather than a recoverable caller error.
     nonisolated func performAsync<T: Sendable>(_ block: @Sendable @escaping () async -> T) -> T {
         do {
             return try AsyncBridge.perform(allowMainThread: true, block)

--- a/Source/AppDelegate+Session.swift
+++ b/Source/AppDelegate+Session.swift
@@ -10,7 +10,6 @@
 
 import Cocoa
 import CoreVideo
-import os.lock
 @preconcurrency import DLABridging
 import DLABCaptureManager
 
@@ -20,88 +19,24 @@ extension Comparable {
     }
 }
 
-private final class UnfairLockBox: @unchecked Sendable {
-    private var rawLock = os_unfair_lock_s()
-    
-    @inline(__always)
-    func withLock<T>(_ body: () throws -> T) rethrows -> T {
-        os_unfair_lock_lock(&rawLock)
-        defer { os_unfair_lock_unlock(&rawLock) }
-        return try body()
-    }
-}
-
 extension AppDelegate {
-    private final class ThrowingAsyncResultBox<T>: @unchecked Sendable {
-        private let lock = UnfairLockBox()
-        private let semaphore = DispatchSemaphore(value: 0)
-        private var result: Result<T, Error>?
-        
-        func store(_ result: Result<T, Error>) {
-            lock.withLock { self.result = result }
-            semaphore.signal()
-        }
-        
-        func waitAndGet() throws -> T {
-            semaphore.wait()
-            return try lock.withLock {
-                guard let result = result else {
-                    fatalError("Async operation failed to complete - this should never happen")
-                }
-                return try result.get()
-            }
-        }
-    }
-    
-    private final class AsyncResultBox<T>: @unchecked Sendable {
-        private let lock = UnfairLockBox()
-        private let semaphore = DispatchSemaphore(value: 0)
-        private var value: T?
-        
-        func store(_ value: T) {
-            lock.withLock { self.value = value }
-            semaphore.signal()
-        }
-        
-        func waitAndGet() -> T {
-            semaphore.wait()
-            return lock.withLock {
-                guard let value = value else {
-                    fatalError("Async operation failed to complete - this should never happen for non-throwing operations")
-                }
-                return value
-            }
-        }
-    }
-    
     /// Executes an asynchronous, throwing operation synchronously.
-    /// - Note: Uses a detached task so the synchronous semaphore wait does not
-    ///   inherit `@MainActor` and deadlock the main thread.
+    /// - Note: AppleScript handlers invoke this on the main thread, so
+    ///   `allowMainThread: true` is required. Block bodies must not await
+    ///   `@MainActor`-isolated work to avoid deadlock.
     nonisolated func performAsync<T: Sendable>(_ block: @Sendable @escaping () async throws -> T) throws -> T {
-        let box = ThrowingAsyncResultBox<T>()
-        
-        Task.detached(priority: .high) { [box, block] in
-            do {
-                box.store(.success(try await block()))
-            } catch {
-                box.store(.failure(error))
-            }
-        }
-        
-        return try box.waitAndGet()
+        return try AsyncBridge.perform(allowMainThread: true, block)
     }
     
     /// Executes an asynchronous, non-throwing operation synchronously.
-    /// - Note: Uses a detached task so the synchronous semaphore wait does not
-    ///   inherit `@MainActor` and deadlock the main thread.
+    /// - Note: A `() async -> T` block satisfies `() async throws -> T`,
+    ///   so the throwing variant of `AsyncBridge.perform` is reused.
     nonisolated func performAsync<T: Sendable>(_ block: @Sendable @escaping () async -> T) -> T {
-        let box = AsyncResultBox<T>()
-        
-        Task.detached(priority: .high) { [box, block] in
-            box.store(await block())
+        do {
+            return try AsyncBridge.perform(allowMainThread: true, block)
+        } catch {
+            fatalError("Non-throwing performAsync unexpectedly threw: \(error)")
         }
-        
-        return box.waitAndGet()
     }
 }
 

--- a/Source/AsyncBridge.swift
+++ b/Source/AsyncBridge.swift
@@ -19,7 +19,7 @@ private final class UnfairLockBox: @unchecked Sendable {
     private var rawLock = os_unfair_lock_s()
     
     @inline(__always)
-    func withLock<T>(_ body: () throws -> T) throws -> T {
+    func withLock<T>(_ body: () throws -> T) rethrows -> T {
         os_unfair_lock_lock(&rawLock)
         defer { os_unfair_lock_unlock(&rawLock) }
         return try body()
@@ -31,8 +31,8 @@ private final class AsyncResultBox<T>: @unchecked Sendable {
     private let semaphore = DispatchSemaphore(value: 0)
     private var value: T?
     
-    func store(_ value: T) throws {
-        try lock.withLock { self.value = value }
+    func store(_ value: T) {
+        lock.withLock { self.value = value }
         semaphore.signal()
     }
     
@@ -63,8 +63,8 @@ private final class ThrowingAsyncResultBox<T>: @unchecked Sendable {
     private let semaphore = DispatchSemaphore(value: 0)
     private var result: Result<T, Error>?
     
-    func store(_ result: Result<T, Error>) throws {
-        try lock.withLock { self.result = result }
+    func store(_ result: Result<T, Error>) {
+        lock.withLock { self.result = result }
         semaphore.signal()
     }
     
@@ -106,9 +106,9 @@ enum AsyncBridge {
         let task = Task.detached(priority: .userInitiated) { [box, block] in
             do {
                 let value = try await block()
-                try box.store(.success(value))
+                box.store(.success(value))
             } catch {
-                try? box.store(.failure(error))
+                box.store(.failure(error))
             }
         }
         do {

--- a/Source/AsyncBridge.swift
+++ b/Source/AsyncBridge.swift
@@ -1,0 +1,121 @@
+//
+//  AsyncBridge.swift
+//  recDL
+//
+//  Unified async-to-sync bridge adopted from performAsync_comparison.md §10.2.
+//
+
+/* This software is released under the MIT License, see LICENSE.txt. */
+
+import Foundation
+import os.lock
+
+enum PerformAsyncError: Error {
+    case timeout(TimeInterval)
+    case operationFailed(String)
+}
+
+private final class UnfairLockBox: @unchecked Sendable {
+    private var rawLock = os_unfair_lock_s()
+    
+    @inline(__always)
+    func withLock<T>(_ body: () throws -> T) throws -> T {
+        os_unfair_lock_lock(&rawLock)
+        defer { os_unfair_lock_unlock(&rawLock) }
+        return try body()
+    }
+}
+
+private final class AsyncResultBox<T>: @unchecked Sendable {
+    private let lock = UnfairLockBox()
+    private let semaphore = DispatchSemaphore(value: 0)
+    private var value: T?
+    
+    func store(_ value: T) throws {
+        try lock.withLock { self.value = value }
+        semaphore.signal()
+    }
+    
+    func waitAndGet(timeout: TimeInterval?) throws -> T {
+        let waitResult: DispatchTimeoutResult
+        if let timeout = timeout {
+            waitResult = semaphore.wait(timeout: .now() + timeout)
+            guard case .success = waitResult else {
+                throw PerformAsyncError.timeout(timeout)
+            }
+        } else {
+            semaphore.wait()
+        }
+        
+        return try lock.withLock {
+            guard let value = value else {
+                throw PerformAsyncError.operationFailed(
+                    "Async operation failed to complete"
+                )
+            }
+            return value
+        }
+    }
+}
+
+private final class ThrowingAsyncResultBox<T>: @unchecked Sendable {
+    private let lock = UnfairLockBox()
+    private let semaphore = DispatchSemaphore(value: 0)
+    private var result: Result<T, Error>?
+    
+    func store(_ result: Result<T, Error>) throws {
+        try lock.withLock { self.result = result }
+        semaphore.signal()
+    }
+    
+    func waitAndGet(timeout: TimeInterval?) throws -> T {
+        let waitResult: DispatchTimeoutResult
+        if let timeout = timeout {
+            waitResult = semaphore.wait(timeout: .now() + timeout)
+            guard case .success = waitResult else {
+                throw PerformAsyncError.timeout(timeout)
+            }
+        } else {
+            semaphore.wait()
+        }
+        
+        return try lock.withLock {
+            guard let result = result else {
+                throw PerformAsyncError.operationFailed(
+                    "Async operation failed to complete"
+                )
+            }
+            return try result.get()
+        }
+    }
+}
+
+enum AsyncBridge {
+    
+    static func perform<T: Sendable>(
+        timeout: TimeInterval? = nil,
+        allowMainThread: Bool = false,
+        _ block: @Sendable @escaping () async throws -> T
+    ) throws -> T {
+        precondition(
+            allowMainThread || !Thread.isMainThread,
+            "AsyncBridge.perform must not be called from the main thread. Use allowMainThread: true if you understand the deadlock risk."
+        )
+        
+        let box = ThrowingAsyncResultBox<T>()
+        let task = Task.detached(priority: .userInitiated) { [box, block] in
+            do {
+                let value = try await block()
+                try box.store(.success(value))
+            } catch {
+                try? box.store(.failure(error))
+            }
+        }
+        do {
+            return try box.waitAndGet(timeout: timeout)
+        } catch {
+            task.cancel()
+            throw error
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Introduce the unified `AsyncBridge` from `performAsync_comparison.md` §10.2 into recDL, replacing the inline `performAsync` plumbing in `AppDelegate+Session.swift`. The throwing `performAsync` overload now surfaces typed `PerformAsyncError` failures (`.timeout` / `.operationFailed`) in place of the prior `fatalError` paths. The non-throwing overload keeps its `fatalError` guard, since a non-throwing block cannot produce a `PerformAsyncError` under normal operation and reaching the `catch` indicates an internal bridge bug rather than a recoverable caller error.

## Commits (3)

- `8bbc479` — Adopt performAsync_comparison.md §10.2 unified AsyncBridge in recDL
- `31af2f1` — Address PR #18 review: relax AsyncBridge store/lock throws signatures (C1–C3; C4 rejected)
- (this PR update) — Document intentional fatalError guard on the non-throwing `performAsync` overload (C5)

## Changes

- Add `Source/AsyncBridge.swift` (new file): unified `AsyncBridge.perform<T: Sendable>(timeout:allowMainThread:_:)` backed by `os_unfair_lock`-protected `AsyncResultBox` / `ThrowingAsyncResultBox`
- Remove the inline `UnfairLockBox`, `ThrowingAsyncResultBox`, and `AsyncResultBox` from `Source/AppDelegate+Session.swift`
- Reduce both `performAsync` variants (throwing + non-throwing) to thin `nonisolated` wrappers that delegate to `AsyncBridge.perform(allowMainThread: true, _)`. AppleScript handlers invoke these on the main thread, so `allowMainThread: true` is required; block bodies must not await `@MainActor`-isolated work to avoid deadlock
- Add a doc-comment note on the non-throwing overload clarifying that its `catch` is intentionally fatal

## Error-handling semantics (clarified per C5)

- Throwing overload `performAsync<T: Sendable>(_ block: @Sendable @escaping () async throws -> T) throws -> T`
  - Surfaces `PerformAsyncError.timeout(_)` when the optional `timeout` elapses
  - Surfaces `PerformAsyncError.operationFailed(_)` if the box state is observed without a stored value
  - Re-throws any error produced by `block`
- Non-throwing overload `performAsync<T: Sendable>(_ block: @Sendable @escaping () async -> T) -> T`
  - Internally uses the throwing `AsyncBridge.perform` overload (a non-throwing block is a subtype of a throwing one)
  - Traps with `fatalError` on the unreachable `catch` path, since a non-throwing block cannot originate a `PerformAsyncError` in normal operation

## Verification

- Xcode Build / Analyze: SUCCEEDED
- Reviewed call sites: `startRecording(for:)`, `stopRecording()`, `updateCachedState()`, and the preparation flows in `AppDelegate+Session.swift` — none await `@MainActor` work inside the `performAsync` blocks, so the `allowMainThread: true` allowance does not introduce a deadlock risk

## Impact

- Behavior change: none on the success path; the throwing overload now reports typed `PerformAsyncError` instead of trapping on the two edge cases
- Public signature change: none
- New file: `Source/AsyncBridge.swift` (project-local; same name as the DLAB SPM/DLABridging copy, but independent)
