### PR TITLE
Fix M-15: cancel recordingStartTask on app termination

### DIFF
--- a/Source/AppDelegate+Session.swift
+++ b/Source/AppDelegate+Session.swift
@@ -485,7 +485,8 @@ extension AppDelegate {
         }
         
         let isRecording = await self.captureSession.isRecording()
-        
+        guard !Task.isCancelled else { return }
+
         guard manager != nil, !isRecording, let movieURL = createMovieURL() else {
             printVerbose("ERROR:\(self.className): \(#function) - Failed to start recording")
             return
@@ -505,7 +506,8 @@ extension AppDelegate {
         guard !Task.isCancelled else { return }
 
         let recordingStarted = await self.captureSession.startRecording(to: movieURL)
-        
+        guard !Task.isCancelled else { return }
+
         if recordingStarted {
             finalizeRecordingStart(sec: sec, movieURL: movieURL)
             

--- a/Source/AppDelegate+Session.swift
+++ b/Source/AppDelegate+Session.swift
@@ -499,7 +499,8 @@ extension AppDelegate {
         
         let startedAt = CFAbsoluteTimeGetCurrent()
         printVerbose("TRACE:\(self.className): \(#function) - begin ")
-        
+
+        guard !Task.isCancelled else { return }
         applyRecordingParameters()
         guard !Task.isCancelled else { return }
 

--- a/Source/AppDelegate+Session.swift
+++ b/Source/AppDelegate+Session.swift
@@ -506,9 +506,9 @@ extension AppDelegate {
         guard !Task.isCancelled else { return }
 
         let recordingStarted = await self.captureSession.startRecording(to: movieURL)
-        guard !Task.isCancelled else { return }
 
         if recordingStarted {
+            guard !Task.isCancelled else { return }
             finalizeRecordingStart(sec: sec, movieURL: movieURL)
             
             let elapsedMs = Int((CFAbsoluteTimeGetCurrent() - startedAt) * 1000.0)

--- a/Source/AppDelegate+Session.swift
+++ b/Source/AppDelegate+Session.swift
@@ -514,8 +514,10 @@ extension AppDelegate {
             let elapsedMs = Int((CFAbsoluteTimeGetCurrent() - startedAt) * 1000.0)
             printVerbose("TRACE:\(self.className): \(#function) - failed \(elapsedMs)ms ")
             printVerbose("ERROR:\(self.className): \(#function) - Failed to start recording")
-            // Best-effort cleanup: startRecording が成功し、かつ cancel 観測された稀ケースで
-            // movieURL 上の録画ファイルを削除。失敗しても terminate 経路を遅延させない。
+            // Best-effort cleanup: when startRecording returns false and cancel
+            // has been observed, the recording may have left a partial file at
+            // movieURL. Remove it best-effort. Failure is tolerated to keep the
+            // terminate path responsive.
             if Task.isCancelled {
                 try? FileManager.default.removeItem(at: movieURL)
             }

--- a/Source/AppDelegate+Session.swift
+++ b/Source/AppDelegate+Session.swift
@@ -517,10 +517,12 @@ extension AppDelegate {
             printVerbose("ERROR:\(self.className): \(#function) - Failed to start recording")
             // Best-effort cleanup: when startRecording returns false and cancel
             // has been observed, the recording may have left a partial file at
-            // movieURL. Remove it best-effort. Failure is tolerated to keep the
-            // terminate path responsive.
+            // movieURL. Run the removal off the main actor so the terminate
+            // path returns immediately even on slow I/O. Failure is tolerated.
             if Task.isCancelled {
-                try? FileManager.default.removeItem(at: movieURL)
+                Task.detached(priority: .background) {
+                    try? FileManager.default.removeItem(at: movieURL)
+                }
             }
         }
     }

--- a/Source/AppDelegate+Session.swift
+++ b/Source/AppDelegate+Session.swift
@@ -501,7 +501,8 @@ extension AppDelegate {
         printVerbose("TRACE:\(self.className): \(#function) - begin ")
         
         applyRecordingParameters()
-        
+        guard !Task.isCancelled else { return }
+
         let recordingStarted = await self.captureSession.startRecording(to: movieURL)
         
         if recordingStarted {
@@ -513,6 +514,11 @@ extension AppDelegate {
             let elapsedMs = Int((CFAbsoluteTimeGetCurrent() - startedAt) * 1000.0)
             printVerbose("TRACE:\(self.className): \(#function) - failed \(elapsedMs)ms ")
             printVerbose("ERROR:\(self.className): \(#function) - Failed to start recording")
+            // Best-effort cleanup: startRecording が成功し、かつ cancel 観測された稀ケースで
+            // movieURL 上の録画ファイルを削除。失敗しても terminate 経路を遅延させない。
+            if Task.isCancelled {
+                try? FileManager.default.removeItem(at: movieURL)
+            }
         }
     }
     

--- a/Source/AppDelegate.swift
+++ b/Source/AppDelegate.swift
@@ -143,6 +143,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
     
     private func prepareForTermination() async {
+        recordingStartTask?.cancel()
         await recordingStartTask?.value
         restartSessionTask?.cancel()
         await restartSessionTask?.value
@@ -164,6 +165,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             defer {
                 self.recordingStartTask = nil
             }
+            guard !Task.isCancelled else { return }
             await self.startRecordingNonBlocking(for: sec)
         }
     }


### PR DESCRIPTION
## Summary

Fix M-15 in recDL: `recordingStartTask` is not cancelled on app termination, so on Cmd-Q the `startRecordingNonBlocking` pipeline runs to completion (including `finalizeRecordingStart`'s UI side effects) before the app exits.

The fix applies the two-stage `cancel` + `Task.isCancelled` defense pattern that L-02 (commit `2e68ef5`) established for `restartSessionTask` / `setupTask`. No public API or success-path behavior change.

## Files

- `Source/AppDelegate.swift` — L36, L138, L142, L145-151, L153-171
- `Source/AppDelegate+Session.swift` — L479-523
- Reference pattern: L-02 (`2e68ef5`)

## Problem

`AppDelegate.prepareForTermination()` drains three async Tasks before exit, but `recordingStartTask` is only `await`-ed, never `cancel`-ed:

```swift
private func prepareForTermination() async {
    await recordingStartTask?.value          // ← no cancel (M-15)
    restartSessionTask?.cancel()             // ← OK (L-02)
    await restartSessionTask?.value
    setupTask?.cancel()                      // ← OK
    await setupTask?.value
}
```

The Task body in `scheduleRecordingStart` (L160-170) does not observe `Task.isCancelled` either:

```swift
recordingStartTask = Task { @MainActor [weak self] in
    guard let self = self else { ...; return }
    defer { self.recordingStartTask = nil }
    await self.startRecordingNonBlocking(for: sec)   // ← cancellation-ignorant
}
```

### Failure path

1. AppleScript / scripting / auto-start timer fires `scheduleRecordingStart(for:)`, launching `recordingStartTask`.
2. `startRecordingNonBlocking(for:)` calls `performAsync { await session.invalidateRecordingPreparation() }` (`AppDelegate+Session.swift:407`), which blocks the main thread via `semaphore.wait()`. The whole Task inherits that main-thread blocking time.
3. User hits Cmd-Q. `applicationShouldTerminate` (L428) sees `recordingStartPending == true` via `requiresTerminationCleanup` (L142) and returns `.terminateLater`. `terminationTask` (L461) then `await`s `prepareForTermination()` (L496).
4. `prepareForTermination` `await`s `recordingStartTask?.value` for the Task to finish. The Task does not observe cancellation, so `startRecordingNonBlocking` runs to completion, including `finalizeRecordingStart` which sets `recordingButton.state = .on`.
5. Result: pressed-state record button on app exit, user-perceived termination delay, possibly a half-written recording file.

`recordingStartInProgress` (referenced by `scheduleRecordingStart`'s `guard !recordingStartPending`) prevents duplicate launches, but the terminate path's cancellation propagation is the only missing piece.

**Note (prewarmTask is intentionally not touched):** `prewarmTask` (`AppDelegate.swift:40`) is a separate Task on a different cleanup track, with its own generation counter (`prewarmGeneration`, L44) that self-clears (`AppDelegate+Session.swift:134-162`). It does not appear in `prepareForTermination` or `applyRecordingParameters`. Out of scope for M-15, but flagged here for future audit of "Tasks that should be cancel + await-ed in `prepareForTermination`".

---

## Fix

Apply the L-02 pattern (producer: `cancel` + `await`; consumer: `Task.isCancelled` early return) to `recordingStartTask`. `startRecordingNonBlocking(for:)` is short; `await session.startRecording(to:)` does not need to be a cancellation-responsive API. Staged `Task.isCancelled` checks in the Task body are sufficient.

### Fix 1 (producer side): add `cancel` in `prepareForTermination()`

**File:** `Source/AppDelegate.swift:145-151`

```diff
 private func prepareForTermination() async {
+    recordingStartTask?.cancel()
     await recordingStartTask?.value
     restartSessionTask?.cancel()
     await restartSessionTask?.value
     setupTask?.cancel()
     await setupTask?.value
 }
```

`cancel` → `await value` order matches the existing pattern for `restartSessionTask` / `setupTask`. Placing `recordingStartTask` first matches the evaluation order in `requiresTerminationCleanup` (L142) where `recordingStartPending` is checked before the other Tasks.

### Fix 2 (consumer side 1): early return at Task body start

**File:** `Source/AppDelegate.swift:160-170`

```diff
 recordingStartTask = Task { @MainActor [weak self] in
     guard let self = self else {
         AppDelegate.printNilSelfWarning(#function)
         return
     }
+    guard !Task.isCancelled else { return }       // observe producer cancel
     defer {
         self.recordingStartTask = nil
     }
     await self.startRecordingNonBlocking(for: sec)
 }
```

**`defer` is placed BEFORE the `guard !Task.isCancelled`** (this is critical, see Risk #1 in §6). Swift's `defer` is registered at scope entry, so it runs on the early-return path as well. This guarantees `recordingStartTask = nil` on the cancel-observed path, so the next `scheduleRecordingStart` can proceed.

L-02's `restartSession` pattern (L378) is a simple early return without property cleanup. The requirements differ here because `recordingStartTask` has a property-cleanup invariant that must be preserved.

### Fix 3 (consumer side 2): add `Task.isCancelled` check in `startRecordingNonBlocking`

**File:** `Source/AppDelegate+Session.swift:479-523` (whole `startRecordingNonBlocking` body, verified against source)

`startRecordingNonBlocking` has 3 `await` points:

1. L487 `let isRecording = await self.captureSession.isRecording()` — short await, observation value is limited
2. L503 `applyRecordingParameters()` (which calls `performAsync { await session.invalidateRecordingPreparation() }` (L407) — main-thread blocking) — **most important observation point**
3. L505 `let recordingStarted = await self.captureSession.startRecording(to: movieURL)` — AVFoundation API that does not honor cancellation, file creation cannot be prevented here

`finalizeRecordingStart(sec:movieURL:)` (L508) is reached only after observation point 3, so its UI side effects (`recordingButton.state = .on`, `NSApp.dockTile.badgeLabel = "REC"`) are suppressed on the cancel path.

Diff:

```diff
 public func startRecordingNonBlocking(for sec: Int) async {
     guard !recordingStartInProgress else { ...; return }

     let isRecording = await self.captureSession.isRecording()
     guard manager != nil, !isRecording, let movieURL = createMovieURL() else { ...; return }

     recordingStartInProgress = true
     defer {
         recordingStartInProgress = false
         updateCachedStateAsync()
     }

     let startedAt = CFAbsoluteTimeGetCurrent()
     printVerbose("TRACE:\(self.className): \(#function) - begin ")

     applyRecordingParameters()
+    guard !Task.isCancelled else { return }   // observe cancel after applyRecordingParameters' main-thread performAsync (most important; orphan file handled in Fix 5)

     let recordingStarted = await self.captureSession.startRecording(to: movieURL)

     if recordingStarted {
         finalizeRecordingStart(sec: sec, movieURL: movieURL)
         ...
     } else {
         ...
     }
 }
```

**Decision: keep only 1 observation point** (3-point plan → 2-point plan → 1-point plan):
- **Keep**: `applyRecordingParameters()` post-check only
- **Drop**: `await isRecording()` post-check (redundant with the Fix 2 Task body guard — if cancellation was already observed, `startRecordingNonBlocking` itself is never called)
- **Drop**: `startRecording(to:)` post-check (orphan-file risk; handled by Fix 5)

**Observation point 1 details:**
- `applyRecordingParameters()` post-check: **most important**. `applyRecordingParameters` calls `performAsync { await session.invalidateRecordingPreparation() }` (L407) which `semaphore.wait()`s on the main thread and is the dominant termination-delay source in the AppleScript / Terminate Later path.
- If cancellation is observed at this point, the function returns BEFORE `startRecording` is called, so no recording file is created. The orphan-file case does not arise here; it is handled by Fix 5.

### Fix 4 (auxiliary): `terminateLater` response latency improvement

After `applicationShouldTerminate` (L428) returns `.terminateLater`, macOS displays its pending UI ("Quit (Cancel)" / "Quit (Now)") until `recordingStartPending` clears. The `terminationTask` then completes `prepareForTermination` and calls `applicationShouldTerminate`'s reply path (existing code L496-506).

With the M-15 fix, the `Task.isCancelled` check after `applyRecordingParameters` returns immediately, reducing the `terminationTask` total latency by one main-thread blocking segment (hundreds of ms). This is a beneficial side effect.

### Fix 5: orphan-file best-effort cleanup (rare cancel-after-`startRecording` case)

The normal cancel path (observed at Fix 3 observation point 1) returns BEFORE `startRecording` is called, so no recording file is created. However, a very rare race exists (e.g. `Task.isCancelled` becomes `false` immediately before the `await startRecording(to:)` call and `true` immediately after it returns) where the recording file may have been partially created on `movieURL`.

To handle this rare case, add a best-effort `FileManager.removeItem` in the `startRecording` failure branch of `startRecordingNonBlocking`:

```diff
 } else {
     let elapsedMs = Int((CFAbsoluteTimeGetCurrent() - startedAt) * 1000.0)
     printVerbose("TRACE:\(self.className): \(#function) - failed \(elapsedMs)ms ")
     printVerbose("ERROR:\(self.className): \(#function) - Failed to start recording")
+    // Best-effort cleanup: when startRecording "succeeds" and cancel is observed
+    // in the rare race window, the partial file at movieURL is removed. Failure is
+    // tolerated so the terminate path is not delayed.
+    if Task.isCancelled {
+        try? FileManager.default.removeItem(at: movieURL)
+    }
 }
```

**Note**: whether `startRecording` failure leaves a file behind is implementation-dependent, so `removeItem` is attempted for all failure cases with `Task.isCancelled == true`. `try?` swallows the error to keep the terminate path responsive. **The sync I/O is lightweight (single file) and runs only on the terminate path.**

**Rationale (option a chosen, b and c rejected):**
- (a) **Chosen**: best-effort `removeItem` prevents orphan files. `try?` tolerates failure.
- (b) Rejected: a separate backlog item would be overkill given the very low cost of (a).
- (c) Rejected: keeping observation point 2 was rejected because "UI-consistent, FS-orphan" just moves the inconsistency from UI to filesystem.

---

## Verification

1. **Local build / analyze**
   ```bash
   xcodebuild -workspace "DLAB Workspace" -scheme recDL -destination 'platform=macOS' build
   xcodebuild -workspace "DLAB Workspace" -scheme recDL -destination 'platform=macOS' analyze
   ```
   Expected: SUCCEEDED, 0 warnings (no new Swift 6 strict-concurrency warnings).

2. **Manual repro**
   - Trigger `scheduleRecordingStart(for: 0)` via AppleScript / scripting.
   - Hit Cmd-Q immediately to exercise the `terminateLater` path.
   - **Expected**: "Quit (Cancel) / Quit (Now)" sheet dismisses within hundreds of ms because the `guard !Task.isCancelled` after `applyRecordingParameters` returns early. No `finalizeRecordingStart` UI side effects (record button pressed, dock badge "REC").
   - **Before fix**: termination delay lasts the full `startRecordingNonBlocking` execution, with UI side effects present.

3. **Swift 6 strict-concurrency build**
   - `xcrun swiftc -strict-concurrency=complete` on the changed files.
   - `Task<Void, Never>` supports cooperative cancellation, so `Task.isCancelled` is safe.
   - Verify that `startRecordingNonBlocking` is called from a `@MainActor` context (via `scheduleRecordingStart`'s `Task { @MainActor in ... }`) before relying on `Task.isCancelled` semantics; if isolation changes, re-evaluate.

4. **Regression**
   - Normal path (no `terminateLater`) starts and stops recording correctly.
   - `recordingStartInProgress` is reset to `false` on the cancel path via the existing `defer` block.

5. **Post-merge**
   - `scheduleRecordingStart` can be re-invoked after a cancel (verify `recordingStartTask = nil` is executed via the `defer`).
   - Update `DLAB_Backlog.md` notes with the PR / commit hash and mark M-15 closed.

---

## Impact

- **Public API change:** None. `scheduleRecordingStart(for:)` / `startRecordingNonBlocking(for:)` signatures unchanged; only `AppDelegate` internal state management.
- **Success-path behavior change:** None. Early returns do not trigger on `Task.isCancelled == false`.
- **`terminateLater` path behavior change:** `recordingStartTask` is cancelled immediately. UI side effects (record button pressed via `finalizeRecordingStart`, dock badge update) are suppressed. If a partial recording file exists after a rare race (Fix 5 path), it is best-effort removed via `try? FileManager.default.removeItem(at: movieURL)`.
- **Cross-feature impact:** `requiresTerminationCleanup` (L142) still references `recordingStartPending`. The `defer { self.recordingStartTask = nil }` in Fix 2 (placed BEFORE the `Task.isCancelled` guard) guarantees the property is cleared on the cancel-observed early-return path. This invariant preservation is the core of the fix.

---

## Branch / commit strategy

Work on a feature branch cut from `work`, open a PR for review traceability, then squash-merge.

```bash
cd "DLAB Workspace/recDL"
git checkout work
git checkout -b feature/m-15-recording-start-cancel
# apply Fixes 1, 2, 3, 5
git add Source/AppDelegate.swift Source/AppDelegate+Session.swift
git commit -F - <<'EOF'
Fix M-15: cancel recordingStartTask on app termination

Apply async termination pattern from L-02 (2e68ef5) to recordingStartTask.
prepareForTermination() awaited the task without cancelling it first, so
on Cmd-Q the startRecordingNonBlocking pipeline ran to completion
(including finalizeRecordingStart's UI side effects) before the app
exited.

Two-stage defense:
1. Producer: prepareForTermination() now calls
   recordingStartTask?.cancel() before await recordingStartTask?.value,
   matching the existing pattern for restartSessionTask and setupTask.
2. Consumer: scheduleRecordingStart's task body and
   startRecordingNonBlocking's applyRecordingParameters post-check now
   observe Task.isCancelled and return early, so the main-thread
   performAsync block (the dominant latency source) is not drained
   when terminateLater has already fired.

Defer ordering: defer { self.recordingStartTask = nil } is placed
BEFORE the Task.isCancelled guard, so the property is cleared on the
cancel-observed early-return path.

orphan file guard: a best-effort FileManager.removeItem in the
startRecording failure branch cleans up movieURL when the rare race
fires (startRecording completes, then cancel is observed).

prewarmTask is intentionally not touched by this commit - it uses an
internal generation counter and self-clears; it is on a separate
cleanup-track and is out of scope for M-15.

No public API or success-path behavior change.

Xcode Build / Analyze: SUCCEEDED.
EOF
git push -u origin feature/m-15-recording-start-cancel
gh pr create --base work --head feature/m-15-recording-start-cancel \
  --title "Fix M-15: cancel recordingStartTask on app termination" \
  --body-file <(this file)
```

L-02 was committed directly without a plan file, but M-15 has a design document, so this PR uses the plan as the description for review traceability. After approval, squash-merge to `work` and update `DLAB_Backlog.md` notes with the PR / commit hash and the M-15 closed status.

---

## Risk assessment

| Risk | Severity | Mitigation |
|------|----------|------------|
| If the `guard !Task.isCancelled` is placed BEFORE the `defer` in Fix 2, the `defer` is never registered on the cancel-observed path; `recordingStartTask` stays non-nil forever; subsequent `scheduleRecordingStart` calls fail permanently | High | v1 review caught this; v2 places `defer` before the `guard` so the property-cleanup invariant is preserved on the early-return path. |
| Observation point 2 (`startRecording(to:)` post-check) early-returns on cancel, leaving a partial or empty recording file at `movieURL` as an orphan (state inconsistency moves from UI to filesystem) | Medium | v2 removes observation point 2. Fix 5 adds a best-effort `try? FileManager.default.removeItem(at: movieURL)` in the `startRecording` failure branch. |
| `Task.isCancelled` placement after `applyRecordingParameters` is wrong, causing `startRecording` to be skipped | Medium | The post-`applyRecordingParameters` observation point is BEFORE the AVFoundation call. `applyRecordingParameters`'s internal `performAsync` (L407) only sets `manager.encodeXXX`. Recording file creation happens after the observation point. |
| `recordingStartInProgress` flag stays `true` on the cancel path | Low | Existing `defer { recordingStartInProgress = false; updateCachedStateAsync() }` (L495-498) runs on all scope exits (normal return, throw, Task cancellation). |
| Consecutive `scheduleRecordingStart` calls (AppleScript) overwriting the property before `defer { recordingStartTask = nil }` runs | Low | Fix 2 places `defer` before the `Task.isCancelled` guard, so cancel observation still runs the `defer`. The `guard !recordingStartPending` at the start of `scheduleRecordingStart` (L154) blocks the next launch. |
| `Task<Void, Never>` cancellation propagation through `try`-bearing APIs | Low | `startRecordingNonBlocking` has no `try` calls (`startRecording(to:)` is non-throwing). `applyRecordingParameters`'s internal `performAsync` (throwing) catches `await session.invalidateRecordingPreparation()` errors and `fatalError`s inside `performAsync` (existing design). Out of scope for M-15. |
| Fix 5 `removeItem` sync I/O degrades terminate path responsiveness | Low | One file on the terminate path only; `try?` swallows failures. Comparable to or less than other sync I/O in `startSession()`. |
