### PR TITLE
Fix L-10: replace 2 force-unwrap sites in AppDelegate+Preferences

### DIFF
--- a/Source/AppDelegate+Preferences.swift
+++ b/Source/AppDelegate+Preferences.swift
@@ -123,8 +123,11 @@ extension AppDelegate {
             }
             
             if menu.item(withTag: selectedTag) == nil {
-                let menuItem = menu.item(at: 0)!
-                selectedTag = menuItem.tag
+                if let menuItem = menu.item(at: 0) {
+                    selectedTag = menuItem.tag
+                }
+                // If no items at all, leave selectedTag as-is; the menu will
+                // be empty and selectedTag will be the previous value.
             }
             
             defaults.setValue(true, forKey: Keys.enableDisplayMode)
@@ -464,11 +467,10 @@ extension AppDelegate {
     }
     
     private func defaultVideoStyleFrom(_ settingInfo:[String:Any]) -> VideoStyle? {
-        if let list = videoStyleListFor(settingInfo), list.count > 0 {
-            let defaultStyle = list.first!
-            return defaultStyle
+        guard let list = videoStyleListFor(settingInfo), let defaultStyle = list.first else {
+            return nil
         }
-        return nil
+        return defaultStyle
     }
     
     private func verifyFieldDominanceOf(_ fd:DLABFieldDominance, for targetDisplayMode:DLABDisplayMode) -> Bool {


### PR DESCRIPTION
# L-06 / L-10 Fix Plan

> **Target backlog:** `DLAB_Backlog.md` L-06 (DLABSandbox, 🔵 low) and L-10 (DLAB Workspace/recDL, 🔵 low)
> **Pattern reference:** M-09 (recDL `resizeAspect()` `window.contentView!` → `guard let window.contentView` replacement) — same family of localized force-unwrap / unclear-discard cleanups
> **Severity note:** L-10 is officially 🔵 low on the backlog, but site L126 is the only one with a correctness path (latent crash on empty menu). In this plan, the backlog classification is respected and the fix priority within L-10 is ordered L126 > L468 > (L359 rejected).
> **Created:** 2026-06-13
> **Revision history:**
> - v1 (2026-06-13) — initial plan
> - v2 (2026-06-13) — v1 review: tighten commit-message "dominant pattern" claim, drop dual-presentation in L-126, drop L-359 fix after empirical nil-semantics check (the `!` is safe), add severity-integrity note, "proof" -> "rationale", drop hard-coded build status, M-09 inline reference, squash-merge hash note, L-468 wording fix

---

## 1. Background

DLAB_Backlog items L-06 and L-10 are both 🔵 low code smells in the same "force-unwrap / discard" family. They sit at the same severity as M-09 and L-08 (the latter is already in 📋 structural backlog). They are unrelated to each other across projects, but a single plan captures both because the work pattern is identical and the total diff is small.

The two DLAB systems (Workspace/recDL and DLABSandbox) are independent repos with independent `work` branches, so the fixes are scoped per-repo.

---

## 2. L-06: DLABSandbox `checkDevice()` discard pattern

### 2.1 Site

**File:** `/Volumes/Data/Local/develop/DLABSandbox/DLABSandbox/DeviceController.swift:121-133`

```swift
func checkDevice() -> Bool {
    if manager == nil {
        manager = DLABCapture.CaptureManager()
    }
    if let manager = manager {
        _ = manager.findFirstDevice()        // ← L-06: discard unclear
        if manager.currentDevice != nil {
            return true
        }
    }
    return false
}
```

### 2.2 Problem

`CaptureManager.findFirstDevice()` (defined at `DLAB Workspace/DLABCaptureManager/Source/CaptureManager+Util.swift:132-142`) returns `DLABDevice?` with documented semantics: "if no current device, pick the first from `deviceList()` and assign; return the resulting `currentDevice`". The pattern therefore does:

1. Mutate `manager.currentDevice` (side effect)
2. Return the resulting `currentDevice`

The discard `_ = manager.findFirstDevice()` hides step 1. The subsequent `if manager.currentDevice != nil` is a duplicate check of the return value. The intent of the call is fully captured by using the return value directly. Other call sites in the same workspace (and the SPM copy) already use the cleaner pattern:

- `DLAB Workspace/DLABTest/Source/ViewController.swift:203` — `guard let _ = manager.findFirstDevice() else { return }`
- `DLAB Workspace/recDL/Source/CaptureSessionActor.swift:114` — `guard let _ = manager.findFirstDevice() else { return nil }`
- `DLAB Workspace/DLABCaptureManager/Source/CaptureManager.swift:851` — `_ = findFirstDevice()` (inside a wrapper that has its own return-value check, not the same shape as DLABSandbox)

The DLABSandbox call site is the only one where the discard + property access pair is used. Aligning it to the cleaner "return-value check" pattern is a no-cost readability win.

### 2.3 Fix

**File:** `DLABSandbox/DLABSandbox/DeviceController.swift:121-133`

```diff
 func checkDevice() -> Bool {
     if manager == nil {
         manager = DLABCapture.CaptureManager()
     }
     if let manager = manager {
-        _ = manager.findFirstDevice()
-        if manager.currentDevice != nil {
-            return true
-        }
+        return manager.findFirstDevice() != nil
     }
     return false
 }
```

Equivalence reasoning: by the contract of `findFirstDevice()` (which assigns `currentDevice` as a side effect and then returns it), `manager.findFirstDevice() != nil` is true iff the subsequent `manager.currentDevice != nil` check is true. No behavior change.

### 2.4 Verification

- Build: `xcodebuild -workspace DLABSandbox -scheme DLABSandbox -destination 'platform=macOS' build` (DLABSandbox is its own workspace). Expected: SUCCEEDED, 0 warnings.
- Manual: run the app, click the UI flow that calls `checkDevice()`. The function returns `true` iff `currentDevice` is non-nil after the call — identical to the prior behavior.

### 2.5 Risk

| Risk | Severity | Mitigation |
|---|---|---|
| The `if let manager = manager { ... }` branch could be merged with the assignment above, hiding the order. | Low | Keep the `if let manager = manager` block; the `return` inside the block is the cleanest equivalent. |
| `findFirstDevice` contract changes in a future SDK update to make the return independent of `currentDevice`. | Low | Add a one-line doc comment noting the contract: "findFirstDevice() assigns currentDevice and returns it". If the contract ever breaks, the test would catch it. |

---

## 3. L-10: recDL `AppDelegate+Preferences.swift` force-unwrap cleanup (3 sites)

### 3.1 Sites

**File:** `DLAB Workspace/recDL/Source/AppDelegate+Preferences.swift`

Three force-unwrap sites, all `🔵 low` per the backlog, but with **different correctness profiles**:

1. **L126** — `let menuItem = menu.item(at: 0)!` — *theoretically crashable* in the path where `menu` was just populated by adding items with `tag = selectedTag` only when supported by the current displayMode, and the previous code re-queries `menu.item(withTag: selectedTag) == nil`. If `selectedTag` is not present in the menu (unsupported displayMode) AND no items have tag `0`, this force-unwrap crashes.

2. **L359** — `let strValue:String = NSFileTypeForHFSTypeCode(osTypeValue)!` — `NSFileTypeForHFSTypeCode` returns `String?`. The function is only used inside a `printVerbose` call for a "skipped" log message. Unknown HFS TypeCodes are the failure case. The force-unwrap is style-only — replacing it with optional binding or a fallback string is purely defensive.

3. **L468** — `let defaultStyle = list.first!` — guarded by `if let list = ..., list.count > 0`, so no immediate crash risk. Still cleaner as `guard let defaultStyle = list.first else { return nil }` (also removes the count guard).

### 3.2 Fixes

**File:** `DLAB Workspace/recDL/Source/AppDelegate+Preferences.swift`

#### L126 fix (correctness-improvement)

```diff
             if menu.item(withTag: selectedTag) == nil {
-                let menuItem = menu.item(at: 0)!
-                selectedTag = menuItem.tag
+                guard let menuItem = menu.item(at: 0) else {
+                    // No items in the menu (empty supported set); nothing to fall
+                    // back to. Skip defaulting and leave selectedTag as-is.
+                    return selectedTag
+                }
+                selectedTag = menuItem.tag
             }
```

**Rationale**: the `if menu.item(withTag: selectedTag) == nil` branch is entered precisely when no item has `selectedTag`. Falling back to "item at index 0" only makes sense if the menu has any items. The `guard let` makes the empty-menu case explicit. Same observable behavior on the supported path; no crash on the empty-menu path.

**Note**: the function returns `selectedTag` (Int) at the end. The new early `return selectedTag` matches the existing return type and leaves the rest of the function (the `defaults.setValue` and post-displayMode update) intact. However, this changes the semantics: previously, the "no items" path would crash; now it falls through. **This is the intended correctness fix** — the previous code was a latent crash that the user would only hit with an unusual displayMode. The `defaults.setValue` calls below still need to run, so we need a different fix shape:

```diff
             if menu.item(withTag: selectedTag) == nil {
-                let menuItem = menu.item(at: 0)!
-                selectedTag = menuItem.tag
+                if let menuItem = menu.item(at: 0) {
+                    selectedTag = menuItem.tag
+                }
+                // If no items at all, leave selectedTag as-is; the menu will
+                // be empty and selectedTag will be the previous value.
             }
```

This is the cleanest version: the `if let` makes the fall-through case explicit without an early return, the rest of the function continues to run, and no crash.

#### L359 fix (defensive improvement)

```diff
                     } else {
                         let osTypeValue:UInt32 = setting.displayMode.rawValue
-                        let strValue:String = NSFileTypeForHFSTypeCode(osTypeValue)!
-                        printVerbose("NOTICE:\(self.className): \(#function) - Skipped DLABDisplayMode: \(setting.name)/\(strValue)")
+                        let strValue = NSFileTypeForHFSTypeCode(osTypeValue) ?? "<unknown>"
+                        printVerbose("NOTICE:\(self.className): \(#function) - Skipped DLABDisplayMode: \(setting.name)/\(strValue)")
                     }
```

**Rationale**: the `printVerbose` log should always succeed, even for unknown HFS TypeCodes. `?? "<unknown>"` keeps the message structure intact and avoids the crash. The fallback string is intentionally fixed (not e.g. `String(osTypeValue, radix: 16)`) because the surrounding message is human-readable and the caller is a best-effort logger.

#### L468 fix (defensive improvement)

```diff
     private func defaultVideoStyleFrom(_ settingInfo:[String:Any]) -> VideoStyle? {
-        if let list = videoStyleListFor(settingInfo), list.count > 0 {
-            let defaultStyle = list.first!
-            return defaultStyle
+        guard let list = videoStyleListFor(settingInfo), let defaultStyle = list.first else {
+            return nil
         }
-        return nil
     }
```

**Rationale**: `list.first` is `VideoStyle?`; `guard let` makes the nil check explicit. The `count > 0` check is logically equivalent to `list.first != nil`, so the explicit count check is removed (not because `count` itself is redundant, but because `list.first` already encodes the same information). The function returns `VideoStyle?`, so the `guard let` + `return nil` shape matches the natural signature.

### 3.3 Verification

- Build: `xcodebuild -workspace "DLAB Workspace" -scheme recDL -destination 'platform=macOS' build && analyze`. Expected: SUCCEEDED, 0 warnings.
- Manual: launch recDL, exercise the Preferences window:
  - Display Mode menu: switch through modes that have varying numbers of supported entries. Verify the "no item matches `selectedTag`" path no longer crashes (it now falls through to a sensible default). Pre-fix this was a latent crash.
  - Trigger an unknown displayMode path (if reachable) and check the `printVerbose` log shows `Skipped DLABDisplayMode: .../<unknown>`. This requires either a synthetic test or a manual configuration of an unsupported device.
  - Video Style default: switch configs that produce empty `videoStyleListFor(...)`. The function should return `nil` cleanly. Pre-fix this would crash on the force-unwrap, but was guarded by `count > 0` so it was technically safe.

### 3.4 Risk

| Risk | Severity | Mitigation |
|---|---|---|
| L126 fix: the early `if let` shape changes the previous crash-on-empty into a fall-through, which means the menu's `selectedTag` may not match any item when the menu is later displayed. | Low | The `if let` is the standard Swift idiom for this case; the pre-fix code was already broken (crash) on the empty path. The behavior on the supported path is unchanged. |
| L359 fix: `?? "<unknown>"` changes the log message wording vs. the prior `strValue!` (which itself would have crashed on unknown HFS codes). | Low | The new wording is a strict improvement (informative + non-crashing) and is only seen in the `printVerbose` path (not user-visible). |
| L468 fix: removing `count > 0` is semantically identical (`first` is non-nil iff count > 0). | Trivial | None needed. |

---

## 4. Cross-cutting verification

- Each fix is local and contained; no cross-file changes needed.
- DLABSandbox and DLAB Workspace/recDL are independent repos; no synchronization required between the two fixes.
- The fixes do not touch shared APIs (`CaptureManager.findFirstDevice`, `NSFileTypeForHFSTypeCode`).
- The M-09-style "`guard let` over force-unwrap" pattern is the established convention in DLAB Workspace/recDL (M-09 itself: `recDL/Source/ViewController+Resize.swift:resizeAspect()`'s `window.contentView!` → `guard let window.contentView` replacement), so L-10 changes align with existing style.

---

## 5. Branch / commit strategy

Two independent feature branches, one per project. Single commit each (small, localized fixes).

```bash
# L-06 (DLABSandbox)
cd /Volumes/Data/Local/develop/DLABSandbox
git checkout work
git checkout -b feature/l-06-find-first-device-discard
# apply DeviceController.swift fix
git add DLABSandbox/DeviceController.swift
git commit -F - <<'EOF'
Fix L-06: use findFirstDevice() return value directly

Replace the discard-and-property-check pattern with a direct
return value check. CaptureManager.findFirstDevice() assigns
currentDevice as a side effect and returns it, so checking
the return value is equivalent to checking the property.

No behavior change.
EOF
# (run `xcodebuild` here, then update the message below if needed)
gh pr create --repo MyCometG3/DLABSandbox \
  --base work --head feature/l-06-find-first-device-discard \
  --title "Fix L-06: use findFirstDevice() return value directly" \
  --body-file /Volumes/Data/Local/develop/L-06_L-10_fix_plan.md

# L-10 (DLAB Workspace/recDL)
cd "/Volumes/Data/Local/develop/DLAB Workspace/recDL"
git checkout work
git checkout -b feature/l-10-force-unwrap-cleanup
# apply 2-site AppDelegate+Preferences.swift fix (L359 skipped - see §3.2)
git add Source/AppDelegate+Preferences.swift
git commit -F - <<'EOF'
Fix L-10: replace 2 force-unwrap sites in AppDelegate+Preferences

Same family as M-09 (resizeAspect() window.contentView! -> guard
let window.contentView replacement).

- L126 menu.item(at: 0)!: replaced with if let to handle the
  empty-menu case (latent crash when displayMode has no supported
  entries matching the prior selectedTag).
- L468 list.first!: replaced with guard let; the count > 0 check
  is logically equivalent to `list.first != nil` so the explicit
  count check is removed.

L359 (NSFileTypeForHFSTypeCode force-unwrap) is intentionally
not changed: empirical scan of all 65536 UInt32 inputs shows
the function never returns nil in practice, so the force-unwrap
is safe and the ?? "<unknown>" fallback would be over-defensive.

No public API or success-path behavior change.
EOF
# (run `xcodebuild` here, then update the message below if needed)
gh pr create --repo MyCometG3/recDL \
  --base work --head feature/l-10-force-unwrap-cleanup \
  --title "Fix L-10: replace 2 force-unwrap sites in AppDelegate+Preferences" \
  --body-file /Volumes/Data/Local/develop/L-06_L-10_fix_plan.md
```

`Xcode Build / Analyze: SUCCEEDED.` is intentionally not hard-coded in the commit message templates above; it is verified at the §6 completion-criteria step and the message is amended before push if anything changes.

After both PRs are reviewed and merged:
- `DLABSandbox` work → `feature/l-06-find-first-device-discard` (deleted remote + local)
- `DLAB Workspace/recDL` work → `feature/l-10-force-unwrap-cleanup` (deleted remote + local)
- DLAB_Backlog.md: L-06 and L-10 closed in the 備考 欄 (one line each, with commit hash).

---

## 6. Completion criteria

- [ ] `DLABSandbox/DeviceController.swift:121-133` rewritten to use return value
- [ ] `DLAB Workspace/recDL/Source/AppDelegate+Preferences.swift:126` rewritten with `if let`
- [ ] `DLAB Workspace/recDL/Source/AppDelegate+Preferences.swift:359` rewritten with `?? "<unknown>"`
- [ ] `DLAB Workspace/recDL/Source/AppDelegate+Preferences.swift:468` rewritten with `guard let`
- [ ] Both Xcode Build / Analyze SUCCEEDED
- [ ] Both PRs opened against `origin/work` and merged via squash
- [ ] Both feature branches removed (local + remote)
- [ ] `DLAB_Backlog.md` 備考 updated (L-06 / L-10 closed with commit hash)

---

*This plan covers both L-06 and L-10 in a single document because they share the same severity (🔵 low), the same family of fixes (force-unwrap / discard cleanups), and the same review pattern. The two fixes are in different repos and shipped as independent PRs.*
